### PR TITLE
Xml space issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -858,6 +858,11 @@
                     "default": "2",
                     "description": "Spaces to be used for indenting XML output. It could be a number or an string. ex. \"2\", \" \" or \"\\t\"."
                 },
+                "vssolution.xmlClosingTagSpace": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Add space at the end of XML closing tag, ex: \" />\""
+                },
                 "vssolution.altSolutionFolders": {
                     "type": "array",
                     "items": {

--- a/src/SolutionExplorerConfiguration.ts
+++ b/src/SolutionExplorerConfiguration.ts
@@ -9,6 +9,7 @@ const ShowOutputChannelName = 'showOutputChannel';
 const NetcoreIgnoreName = 'netcoreIgnore';
 const AlternativeSolutionFoldersName = 'altSolutionFolders';
 const XmlSpacesName = 'xmlspaces';
+const XmlClosingTagSpace = 'xmlClosingTagSpace';
 
 let config: vscode.WorkspaceConfiguration = null;
 
@@ -58,6 +59,10 @@ export function getXmlSpaces(): string | number {
     } else {
         return parseInt(value);
     }
+}
+
+export function getXmlClosingTagSpace(): boolean {
+    return config.get<boolean>(XmlClosingTagSpace, false);
 }
 
 export const ICONS_THEME = "current-theme";

--- a/src/async/xml.ts
+++ b/src/async/xml.ts
@@ -21,5 +21,9 @@ export function ParseToJson(content: string): Promise<any> {
 export function ParseToXml(content: any): Promise<string> {
     writeOptions.spaces = config.getXmlSpaces();
     let result = convert.js2xml(content, writeOptions);
+    if (config.getXmlClosingTagSpace()) {
+        let re = /([A-Za-z0-9_\"]+)\/\>/g;
+        result = result.replace(re,"$1 />");
+    }
     return Promise.resolve(result);
 }

--- a/src/commands/parameters/InputOptionsCommandParameter.ts
+++ b/src/commands/parameters/InputOptionsCommandParameter.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import { ICommandParameter } from "../base/ICommandParameter";
-import { parseString } from "xml2js";
 
 export type ItemsResolver = () => Promise<string[]>;
 

--- a/src/model/Projects/Kinds/StandardProject.ts
+++ b/src/model/Projects/Kinds/StandardProject.ts
@@ -278,28 +278,30 @@ export class StandardProject extends FileSystemBasedProject {
 
         project.elements.forEach(element => {
             if (element.name === 'ItemGroup') {
-                element.elements.forEach(e => {
-                    if (e.name === 'Reference') {
-                        let include = this.cleanIncludePath(e.attributes.Include);
-                        this.references.push(new ProjectReference(include, include));
-                        return false;
-                    }
-
-                    if (e.name === 'Folder') {
-                        addFile(e);
-                        let folder = this.cleanIncludePath(e.attributes.Include).replace(/\\/g, path.sep);
-                        if (folder.endsWith(path.sep))
-                            folder = folder.substring(0, folder.length - 1);
-                        folders.push(folder);
-                        return false;
-                    }
-
-                    nodeNames.forEach(nodeName => {
-                        if (e.name === nodeName) {
-                            addFile(e);
+                if (element.elements) {
+                    element.elements.forEach(e => {
+                        if (e.name === 'Reference') {
+                            let include = this.cleanIncludePath(e.attributes.Include);
+                            this.references.push(new ProjectReference(include, include));
+                            return false;
                         }
+
+                        if (e.name === 'Folder') {
+                            addFile(e);
+                            let folder = this.cleanIncludePath(e.attributes.Include).replace(/\\/g, path.sep);
+                            if (folder.endsWith(path.sep))
+                                folder = folder.substring(0, folder.length - 1);
+                            folders.push(folder);
+                            return false;
+                        }
+
+                        nodeNames.forEach(nodeName => {
+                            if (e.name === nodeName) {
+                                addFile(e);
+                            }
+                        });
                     });
-                });
+                }
             }
         });
 


### PR DESCRIPTION
- Relates to issue #26 
- Adds a new option: xmlClosingTagSpace
- when xmlClosingTagSpace is enabled, closing tags are written as: " />" rather than "/>" - this is for Visual Studio compatibility
