### PR TITLE
Support for workspaces

### DIFF
--- a/src/commands/CreateFileCommand.ts
+++ b/src/commands/CreateFileCommand.ts
@@ -40,13 +40,13 @@ export class CreateFileCommand extends CommandBase {
 
     private async getTemplatesTypes(): Promise<string[]> {
         let extension = path.extname(this.args[0]).substring(1);
-        let result: string[] =  await this.provider.templateEngine.getTemplates(extension);
+        let result: string[] =  await this.provider.defaultTemplateEngine.getTemplates(extension);
         return result;
     }
 
     private getContent(item: TreeItem): Promise<string> {
         if (!this.args[1]) return Promise.resolve("");
 
-        return this.provider.templateEngine.generate(this.args[0], this.args[1], item);
+        return this.provider.defaultTemplateEngine.generate(this.args[0], this.args[1], item);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,9 +11,8 @@ import { SolutionExplorerOutputChannel } from "./SolutionExplorerOutputChannel";
 var eventAggregator, solutionExplorerProvider, solutionExplorerCommands, solutionExplorerFileWatcher, solutionExplorerOutputChannel;
 
 export function activate(context: vscode.ExtensionContext) {
-    const rootPath = vscode.workspace.rootPath;
     eventAggregator = new EventAggregator();
-    solutionExplorerProvider = new SolutionExplorerProvider(rootPath, eventAggregator);
+    solutionExplorerProvider = new SolutionExplorerProvider(vscode.workspace.workspaceFolders, eventAggregator);
     solutionExplorerCommands = new SolutionExplorerCommands(context, solutionExplorerProvider);
     solutionExplorerFileWatcher = new SolutionExplorerFileWatcher(eventAggregator);
     solutionExplorerOutputChannel = new SolutionExplorerOutputChannel(eventAggregator);

--- a/src/templates/ITemplateEngine.ts
+++ b/src/templates/ITemplateEngine.ts
@@ -4,5 +4,5 @@ export interface ITemplateEngine {
     getTemplates(extension: string): Promise<string[]>;
     generate(filename: string, templateName: string, item: TreeItem): Promise<string>;
     existsTemplates(): Promise<boolean>;
-    creteTemplates(): Promise<void>;
+    createTemplates(): Promise<void>;
 }

--- a/src/templates/TemplateEngine.ts
+++ b/src/templates/TemplateEngine.ts
@@ -10,6 +10,7 @@ const TemplateFilename: string = "template-list.json";
 const SourceFolder: string = path.join(__filename, "..", "..", "..", "files-vscode-folder");
 
 export class TemplateEngine {
+    private readonly workspaceName: string;
     private readonly workspaceRoot: string;
     private readonly vscodeFolder: string;
     private readonly workingFolder: string;
@@ -18,7 +19,8 @@ export class TemplateEngine {
     private templates: ITemplate[];
     
 
-    constructor(workspaceRoot: string) {
+    constructor(workspaceName: string, workspaceRoot: string) {
+        this.workspaceName = workspaceName;
         this.workspaceRoot = workspaceRoot;
         this.vscodeFolder = path.join(workspaceRoot, VsCodeFoldername);
         this.workingFolder = path.join(workspaceRoot, VsCodeFoldername, TemplateFoldername);


### PR DESCRIPTION
First of all I would like to mention that I really like this VS Code extensions. What I noticed was that although the extension works when using workspaces it only selects the first folder.

This PR makes some changes regarding the building of the solution explorer by iteration over all available folders in a workspace.

Some things are still left over....
- What to do when it discovers workspace folders without a solution and how to represent this?
- How does the template discovery works over multiple workspace folders with their own templates?