### PR TITLE
Add an option to disable the question about creating the solution template folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -935,6 +935,11 @@
                         "950": "BIG5"
                     },
                     "description": "Win32 codepage -> iconv.js encoding equivalences."
+                },
+                "vssolution.createTemplateFolderQuestion": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Ask to create the solution template folder when none exists."
                 }
             }
         }

--- a/src/SolutionExplorerConfiguration.ts
+++ b/src/SolutionExplorerConfiguration.ts
@@ -11,6 +11,7 @@ const AlternativeSolutionFoldersName = 'altSolutionFolders';
 const XmlSpacesName = 'xmlspaces';
 const XmlClosingTagSpace = 'xmlClosingTagSpace';
 const Win32EncodingName = 'win32Encoding';
+const CreateTemplateFolderQuestion = 'createTemplateFolderQuestion';
 
 let config: vscode.WorkspaceConfiguration = null;
 
@@ -72,6 +73,10 @@ export function getWin32EncodingTable(): { [id: string]: string } {
         "936": "GBK",
         "950": "BIG5"
     });
+}
+
+export function getCreateTemplateFolderQuestion() : boolean {
+    return config.get<boolean>(CreateTemplateFolderQuestion, true);
 }
 
 export const ICONS_THEME = "current-theme";

--- a/src/SolutionExplorerProvider.ts
+++ b/src/SolutionExplorerProvider.ts
@@ -148,7 +148,7 @@ export class SolutionExplorerProvider implements vscode.TreeDataProvider<sln.Tre
 	}
 
 	private async checkTemplatesToInstall(): Promise<void> {
-		if (!(await this.templateEngine.existsTemplates())) {
+		if (SolutionExplorerConfiguration.getCreateTemplateFolderQuestion() && !(await this.templateEngine.existsTemplates())) {
 			let option = await vscode.window.showWarningMessage("Would you like to create the vscode-solution-explorer templates folder?", 'Yes', 'No');
 			if (option !== null && option !== undefined && option == 'Yes') {
 				await this.templateEngine.creteTemplates();


### PR DESCRIPTION
I personally don't use templates in every project, but vscode-solution-explorer keeps nagging me when opening a new workspace.