### PR TITLE
Properly handle project files with paths outside the project root

### DIFF
--- a/src/model/Projects/Kinds/StandardProject.ts
+++ b/src/model/Projects/Kinds/StandardProject.ts
@@ -179,7 +179,6 @@ export class StandardProject extends FileSystemBasedProject {
     }
 
     public async getFolderList(): Promise<string[]> {
-        let folderPath = path.dirname(this.projectInSolution.fullPath);
         let directories = await this.getFoldersFromTree(this.filesTree);
 
         directories.sort((a, b) => {

--- a/src/model/Projects/Kinds/StandardProject.ts
+++ b/src/model/Projects/Kinds/StandardProject.ts
@@ -9,6 +9,20 @@ import { PackageReference } from "../PackageReference";
 import { ProjectReference } from "../ProjectReference";
 import { FileSystemBasedProject } from "./FileSystemBasedProject";
 
+function commonPrefix(x: string, y: string): string {
+    if (x > y) {
+        [x, y] = [y, x];
+    }
+
+    let i = 0;
+    for (; i < x.length; i++) {
+        if (x[i] != y[i]) {
+            break;
+        }
+    }
+    return x.substr(0, i);
+}
+
 export class StandardProject extends FileSystemBasedProject {
     private loaded: boolean = false;
     private loadedPackages: boolean = false;
@@ -175,7 +189,7 @@ export class StandardProject extends FileSystemBasedProject {
         });
 
         let result: string[] = [ '.' + path.sep ];
-        directories.forEach(dirPath => result.push('.' + dirPath.replace(folderPath, '')));
+        directories.forEach(dirPath => result.push(this.getRelativePath(dirPath)));
         return result;
     }
 
@@ -326,10 +340,16 @@ export class StandardProject extends FileSystemBasedProject {
     private parseToTree(files: string[]): any {
         let tree = [];
         files.forEach(filepath => {
+            // Get absolute path of file
             filepath = filepath.replace(/\\/g, path.sep);
-            let pathParts = filepath.split(path.sep);
+            filepath = path.resolve(path.dirname(this.fullPath), filepath);
+
+            // Trim the leading path that the file and project file share
+            let currentFullPath = commonPrefix(path.dirname(this.fullPath), filepath);
+            let virtualPath = path.relative(currentFullPath, filepath);
+
+            let pathParts = virtualPath.split(path.sep);
             let currentLevel = tree;
-            let currentFullPath = path.dirname(this.fullPath);
             pathParts.forEach(part => {
                 if (!part) return;
                 currentFullPath = path.join(currentFullPath, part);
@@ -339,7 +359,7 @@ export class StandardProject extends FileSystemBasedProject {
                 } else {
                     let newPart = {
                         name: part,
-                        virtualpath: filepath,
+                        virtualpath: virtualPath,
                         fullpath: currentFullPath,
                         children: [],
                     }
@@ -513,11 +533,7 @@ export class StandardProject extends FileSystemBasedProject {
     }
 
     private getRelativePath(fullpath: string): string {
-        let relativePath = fullpath.replace(path.dirname(this.fullPath), '');
-        if (relativePath.startsWith(path.sep))
-            relativePath = relativePath.substring(1);
-
-        return relativePath;
+        return path.relative(path.dirname(this.fullPath), fullpath);
     }
 
     private async getFoldersFromTree(items: any): Promise<string[]> {


### PR DESCRIPTION
Currently, this extension assumes that all files in a project will be in directories adjacent to or beneath the location of the project file. I have a few projects that reference files located a few directories up from the project file and trying to load them completely breaks the extension:

![recursion](https://user-images.githubusercontent.com/9356790/48306068-2ac4c000-e503-11e8-8135-3b795e624e3b.png)
(files in `src` are referenced as `..\..\..\src\file.ext` but the tree is rendered as "src within src" forever)

This PR adds support for such projects. Files with relative paths will now be included in the tree with virtual paths beginning at the first directory that a given file does not have in common with the project file.

Example:

If the project file is located at `Path\To\Proj\ProjectName.csproj` and there is a file included from `Path\To\Source\File.cs` (i.e., as `<Compile Include="..\Source\File.cs">`) then the tree view will appear as:

```
+SLNName
-+ProjectName
--+Source
---+File.cs
```

File/folder creation, deletion, moving, and renaming also now works for such files. 