### PR TITLE
fix: convert dash to underscore in namespace

### DIFF
--- a/files-vscode-folder/template-parameters.js
+++ b/files-vscode-folder/template-parameters.js
@@ -7,6 +7,7 @@ module.exports = function(filename, projectPath, folderPath) {
         if (folderPath) {
             namespace += "." + folderPath.replace(path.dirname(projectPath), "").substring(1).replace(/[\\\/]/g, ".");
         }
+        namespace = namespace.replace(/[\\\-]/g, "_");
     }       
 
     return {


### PR DESCRIPTION
namespaces dont support dash char (-)
if project or file name contains dash, template system replace to underscore (_).