### PR TITLE
Added a new Locate Command

### DIFF
--- a/src/SolutionExplorerCommands.ts
+++ b/src/SolutionExplorerCommands.ts
@@ -39,6 +39,8 @@ export class SolutionExplorerCommands {
         this.commands['restore'] = new cmds.RestoreCommand(provider);
         this.commands['run'] = new cmds.RunCommand(provider);
         this.commands['test'] = new cmds.TestCommand(provider);
+        this.commands['locate'] = new cmds.LocateCommand(provider);
+        
     }
 
     public register() {

--- a/src/SolutionExplorerCommands.ts
+++ b/src/SolutionExplorerCommands.ts
@@ -40,7 +40,6 @@ export class SolutionExplorerCommands {
         this.commands['run'] = new cmds.RunCommand(provider);
         this.commands['test'] = new cmds.TestCommand(provider);
         this.commands['locate'] = new cmds.LocateCommand(provider);
-        
     }
 
     public register() {

--- a/src/SolutionExplorerProvider.ts
+++ b/src/SolutionExplorerProvider.ts
@@ -92,7 +92,7 @@ export class SolutionExplorerProvider implements vscode.TreeDataProvider<sln.Tre
 		return element.parent;
 	}
 
-	private async selectFile(filepath: string): Promise<void> {
+	public async selectFile(filepath: string): Promise<void> {
 		if (!this.children) return;
 		for(let i = 0; i < this.children.length; i++) {
 			let result = await this.children[i].search(filepath);

--- a/src/commands/LocateCommand.ts
+++ b/src/commands/LocateCommand.ts
@@ -1,0 +1,23 @@
+import { CommandBase } from "./base/CommandBase";
+import { SolutionExplorerProvider } from "../SolutionExplorerProvider";
+import { TreeItem } from "../tree/TreeItem";
+import { StaticCommandParameter } from "./parameters/StaticCommandParameter";
+import { ContextValues } from "../tree";
+import * as vscode from "vscode";
+
+
+export class LocateCommand extends CommandBase {
+    private _provider: SolutionExplorerProvider;
+    constructor(provider: SolutionExplorerProvider) {
+        super('Locate');
+        this._provider = provider;
+    }
+
+    protected shouldRun(item: TreeItem): boolean {
+        return true;
+    }
+
+    protected async runCommand(item: TreeItem, args: string[]): Promise<void> {
+		this._provider.selectFile(vscode.window.activeTextEditor.document.uri.fsPath);    
+    }
+}

--- a/src/commands/LocateCommand.ts
+++ b/src/commands/LocateCommand.ts
@@ -1,8 +1,6 @@
 import { CommandBase } from "./base/CommandBase";
 import { SolutionExplorerProvider } from "../SolutionExplorerProvider";
 import { TreeItem } from "../tree/TreeItem";
-import { StaticCommandParameter } from "./parameters/StaticCommandParameter";
-import { ContextValues } from "../tree";
 import * as vscode from "vscode";
 
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -29,3 +29,4 @@ export * from "./PublishCommand";
 export * from "./RestoreCommand";
 export * from "./RunCommand";
 export * from "./TestCommand";
+export * from "./LocateCommand";


### PR DESCRIPTION
I made a new Locate command that locates the active editor in the Solution Explorer. I use this shortcut in Visual Studio all the times - and I missed it in this plugin