### PR TITLE
Fix: When searching for a file it will stop searching if it encounter a folder that does not exist 

### DIFF
--- a/src/tree/TreeItem.ts
+++ b/src/tree/TreeItem.ts
@@ -53,7 +53,11 @@ export abstract class TreeItem extends vscode.TreeItem {
 	public async getChildren(): Promise<TreeItem[]> {
         if (!this.children) {
 			let childContext = this.context.copy(null, this);
-			this.children = await this.createChildren(childContext);
+			try {
+				this.children = await this.createChildren(childContext);
+			} catch {
+				this.children = [];
+			}
         }
 		
 		return this.children;
@@ -79,7 +83,11 @@ export abstract class TreeItem extends vscode.TreeItem {
 
 			let dirname = path.dirname(this.path);
 			if (filepath.startsWith(dirname)) {
-				await this.getChildren();
+				try {
+					await this.getChildren();
+				} catch {
+					return null;
+				}
 				for(let i = 0; i < this.children.length; i++) {
 					let result = await this.children[i].search(filepath);
 					if (result) return result;


### PR DESCRIPTION
This problem happens a lot in our code base and git.

Because Git does not commit empty folders without a .gitkeep file - it will not checkout the folder - but the folder is still present in the .csproj file. If you then try to locate a file and it encounters a folder that does not exist - it will reject the promise - and that "branch" of the search will be short-circuited.