### PR TITLE
Defensive check for empty `<ItemGroup />` items in `.csproj`

### DIFF
--- a/src/model/Projects/Kinds/CpsProject.ts
+++ b/src/model/Projects/Kinds/CpsProject.ts
@@ -93,6 +93,7 @@ export class CpsProject extends FileSystemBasedProject {
         
         project.elements.forEach(element => {
             if (element.name === 'ItemGroup') {
+                if (!element.elements || !Array.isArray(element.elements)) element.elements = [];
                 element.elements.forEach(e => {
                     if (e.name === 'PackageReference') {
                         this.packages.push(new PackageReference(e.attributes.Include, e.attributes.Include));


### PR DESCRIPTION
Related to this: #80