### PR TITLE
Added ProjectReference and CustomBuild item support to StandardProject

### DIFF
--- a/src/model/Projects/Kinds/StandardProject.ts
+++ b/src/model/Projects/Kinds/StandardProject.ts
@@ -294,7 +294,7 @@ export class StandardProject extends FileSystemBasedProject {
                 if (!element.elements || !Array.isArray(element.elements)) element.elements = [];
                 
                 element.elements.forEach(e => {
-                    if (e.name === 'Reference') {
+                    if (e.name === 'Reference' || e.name === 'ProjectReference') {
                         let include = this.cleanIncludePath(e.attributes.Include);
                         this.references.push(new ProjectReference(include, include));
                         return false;
@@ -570,6 +570,7 @@ export class StandardProject extends FileSystemBasedProject {
             "ClInclude",
             "Content",
             "TypeScriptCompile",
+            "CustomBuild",
             "EmbeddedResource",
             "None",
             "Folder"


### PR DESCRIPTION
Noticed that one of the solutions I'm working on was missing some project references and it turns out that two tags were missing form StandardProject class: ProjectReference for projects and CustomBuild for items. This PR should fix these two.