### PR TITLE
Add project to solution error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-solution-explorer",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/commands/base/CliCommandBase.ts
+++ b/src/commands/base/CliCommandBase.ts
@@ -25,7 +25,7 @@ export abstract class CliCommandBase extends CommandBase {
     protected runCliCommand(app: string, args: string[], path: string): Promise<void> {
         this.checkCurrentEncoding();
 
-        const terminal = this.ensureTerminal();
+        const terminal = this.ensureTerminal(path);
 
         let cargs: string[] = Array<string>(args.length);
         args.forEach((a, index) => cargs[index] = '"' + a + '"');
@@ -61,11 +61,13 @@ export abstract class CliCommandBase extends CommandBase {
         return data.toString();
     }
 
-    private ensureTerminal(): vscode.Terminal {
+    private ensureTerminal(path: string): vscode.Terminal {
         let terminal: vscode.Terminal;
         vscode.window.terminals.forEach(t => { if(t.name === TERMINAL_NAME) terminal = t; });
         if (!terminal) {
-            terminal = vscode.window.createTerminal(TERMINAL_NAME);
+            terminal = vscode.window.createTerminal({ name: TERMINAL_NAME, cwd: path });
+        } else {
+            terminal.sendText( [ "cd", path ].join(' '), true);
         }
 
         return terminal;


### PR DESCRIPTION
When .sln file isn't in root but in one of the `AlternativeSolutionFolders` the `dotnet add `command executes always in root folder leading to when error when adding the newly created project to the solution file.