### PR TITLE
Don't focus tree when tracking active file.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-solution-explorer",
-    "version": "0.3.9",
+    "version": "0.3.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/SolutionExplorerProvider.ts
+++ b/src/SolutionExplorerProvider.ts
@@ -41,7 +41,7 @@ export class SolutionExplorerProvider extends vscode.Disposable implements vscod
 		vscode.commands.executeCommand('setContext', 'solutionExplorer.viewInExplorer', showMode === SolutionExplorerConfiguration.SHOW_MODE_EXPLORER);
 		vscode.commands.executeCommand('setContext', 'solutionExplorer.viewInNone', showMode === SolutionExplorerConfiguration.SHOW_MODE_NONE);
 		vscode.commands.executeCommand('setContext', 'solutionExplorer.loadedFlag', !false);
-		
+
 		if (showMode !== SolutionExplorerConfiguration.SHOW_MODE_NONE) {
 			this.subscription = this.eventAggregator.subscribe(EventTypes.File, evt => this.onFileEvent(evt))
 			if (showMode === SolutionExplorerConfiguration.SHOW_MODE_ACTIVITYBAR) {
@@ -79,13 +79,13 @@ export class SolutionExplorerProvider extends vscode.Disposable implements vscod
 			this.logger.log('No .sln found in workspace');
 			return Promise.resolve([]);
 		}
-		
+
 		if (element)
 			return element.getChildren();
-		
-		if (!element && this.children) 
+
+		if (!element && this.children)
 			return Promise.resolve(this.children);
-	
+
 		if (!element && !this.children) {
 			return this.createSolutionItems();
 		}
@@ -110,7 +110,7 @@ export class SolutionExplorerProvider extends vscode.Disposable implements vscod
 
 	private selectTreeItem(element: sln.TreeItem): void {
 		if (this.treeView) {
-			this.treeView.reveal(element, { select: true, focus: true });
+			this.treeView.reveal(element, { select: true, focus: false });
 		}
 	}
 
@@ -123,13 +123,13 @@ export class SolutionExplorerProvider extends vscode.Disposable implements vscod
 				let altSolutionPaths = await Utilities.searchFilesInDir(path.join(this.workspaceRoot, altFolders[i]), '.sln');
 				solutionPaths = [ ...solutionPaths, ...altSolutionPaths]
 			}
-			
+
 			if (solutionPaths.length <= 0) {
 				this.children .push(await sln.CreateNoSolution(this, this.workspaceRoot));
 				return this.children;
 			}
 		}
-		
+
 		for(let i = 0; i < solutionPaths.length; i++) {
 			let s = solutionPaths[i];
 			let solution = await SolutionFile.Parse(s);
@@ -145,7 +145,7 @@ export class SolutionExplorerProvider extends vscode.Disposable implements vscod
 	private onFileEvent(event: IEvent): void {
         let fileEvent = <IFileEvent> event;
 
-		if (path.dirname(fileEvent.path) == this.workspaceRoot 
+		if (path.dirname(fileEvent.path) == this.workspaceRoot
 		    && fileEvent.path.endsWith('.sln')) {
 			this.children = null;
 			this.refresh();
@@ -166,12 +166,12 @@ export class SolutionExplorerProvider extends vscode.Disposable implements vscod
 		if (!shouldExecute) return;
 		if (!vscode.window.activeTextEditor) return;
 		if (vscode.window.activeTextEditor.document.uri.scheme !== 'file') return;
-		
-		this.selectFile(vscode.window.activeTextEditor.document.uri.fsPath); 
+
+		this.selectFile(vscode.window.activeTextEditor.document.uri.fsPath);
 	}
 
 	private onVisibleEditorsChanged(editors: vscode.TextEditor[]): void {
-		
+
 	}
 }
 

--- a/src/SolutionExplorerProvider.ts
+++ b/src/SolutionExplorerProvider.ts
@@ -25,7 +25,7 @@ export class SolutionExplorerProvider extends vscode.Disposable implements vscod
 		this._templateEngine = new TemplateEngine(workspaceRoot);
 		vscode.window.onDidChangeActiveTextEditor(() => this.onActiveEditorChanged());
 		vscode.window.onDidChangeVisibleTextEditors(data => this.onVisibleEditorsChanged(data));
-	}
+  }
 
 	public get logger(): ILogger {
 		return this._logger;
@@ -109,7 +109,7 @@ export class SolutionExplorerProvider extends vscode.Disposable implements vscod
 	}
 
 	private selectTreeItem(element: sln.TreeItem): void {
-		if (this.treeView) {
+		if (this.treeView && this.treeView.visible) {
 			this.treeView.reveal(element, { select: true, focus: false });
 		}
 	}
@@ -174,11 +174,4 @@ export class SolutionExplorerProvider extends vscode.Disposable implements vscod
 
 	}
 }
-
-
-
-
-
-
-
 


### PR DESCRIPTION
This is a really small change but is essential for people who uses vim keybindings. When going to definitions of functions, it changes the focus to the solution explorer which breaks the mouseless experience.