### PR TITLE
Features/partialclasssupport Add support for partial class naming conventions in files

### DIFF
--- a/src/tree/TreeItemFactory.ts
+++ b/src/tree/TreeItemFactory.ts
@@ -136,6 +136,18 @@ export async function CreateItemsFromProject(context: TreeItemContext, project: 
                     result.push(new ProjectFileTreeItem(context, cs));
                 }
             } else if(handledPartialClasses.indexOf(cs.fullPath) === -1) {
+                let className = cs.name.split(".")[0];
+
+                let relatedFiles = csharpFiles.filter(r => {
+                    if(r.name.split(".").length === 2) { return false; }
+                    let otherClassName = r.name.split(".")[0];
+                    return className == otherClassName;
+                });
+
+                if(relatedFiles.length > 0) {
+                    handledPartialClasses.push(cs.fullPath);
+                }
+
                 result.push(new ProjectFileTreeItem(context, cs));
             }
         });

--- a/src/tree/items/ProjectFileTreeItem.ts
+++ b/src/tree/items/ProjectFileTreeItem.ts
@@ -6,8 +6,8 @@ import { Project } from "../../model/Projects";
 import { ProjectFile } from "../../model/Projects/ProjectFile";
 
 export class ProjectFileTreeItem extends TreeItem {
-    constructor(context: TreeItemContext, private readonly projectFile: ProjectFile) {
-        super(context, projectFile.name, projectFile.hasDependents ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None, ContextValues.ProjectFile, projectFile.fullPath);
+    constructor(context: TreeItemContext, private readonly projectFile: ProjectFile, private readonly relatedFiles: ProjectFile[] = []) {
+        super(context, projectFile.name, (projectFile.hasDependents || relatedFiles.length > 0) ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None, ContextValues.ProjectFile, projectFile.fullPath);
     }
 
     command = {
@@ -21,6 +21,11 @@ export class ProjectFileTreeItem extends TreeItem {
 		if (this.projectFile.dependents) {
             this.projectFile.dependents.forEach(d => {
                 result.push(new ProjectFileTreeItem(childContext, d));
+            });
+        }
+        if(this.relatedFiles.length > 0) {
+            this.relatedFiles.forEach(f => {
+                result.push(new ProjectFileTreeItem(this.context, f));
             });
         }
 


### PR DESCRIPTION
In the later versions of Visual Studio Enterprise Preview builds it performs the following...

![image](https://user-images.githubusercontent.com/9967255/171611801-e528299f-484c-4be9-854f-5dae3800f55e.png)

This allows to group relevant functionality under one partial class & file entry...
My goal here is to reproduce the same grouping by default in VSCode which is what this pull request accomplishes...

![image](https://user-images.githubusercontent.com/9967255/171612008-e968b0af-4ff9-4dbf-ae04-859ee9aee2e1.png)
