### PR TITLE
List can contain the same project items more than once because of entries in csproj file

### DIFF
--- a/src/tree/TreeItemFactory.ts
+++ b/src/tree/TreeItemFactory.ts
@@ -89,9 +89,17 @@ export async function createItemsFromProject(context: TreeItemContext, project: 
     if (!virtualPath) { virtualPath = "."; }
 
     const result: TreeItem[] = [];
-    const items = await project.getProjectItemEntries();
+    
+    const unFilteredItems = await project.getProjectItemEntries();
+    let items: ProjectItemEntry[] = []
+    unFilteredItems.forEach(x => {
+        if (items.findIndex(y => y.fullPath == x.fullPath) == -1)
+            items.push(x);
+    });
+
     const folders = items.filter(i => i.isDirectory && path.dirname(i.relativePath) === virtualPath);
     const files = items.filter(i => !i.isDirectory && path.dirname(i.relativePath) === virtualPath && !i.dependentUpon);
+
 
     if (!project.fullPath.endsWith('.fsproj')) {
         const head = ['properties','wwwroot']
@@ -110,6 +118,7 @@ export async function createItemsFromProject(context: TreeItemContext, project: 
                 return  x < y ? -1 : x > y ? 1 : 0;
             }
         });
+
         files.sort((a, b) => {
             const x : string = a.name.toLowerCase();
             const y : string = b.name.toLowerCase();


### PR DESCRIPTION
Somehow folders or files end up multiple times in the list because they are explicitly mentioned in the csproj file (old csproj file)