### PR TITLE
Fix project expansion

### DIFF
--- a/src/core/Projects/Items/ProjectItemsFactory.ts
+++ b/src/core/Projects/Items/ProjectItemsFactory.ts
@@ -106,7 +106,10 @@ function toOSPath(input: string): string {
     if (!input) {
         return input;
     }
-    return input.replace(/\\/g, path.sep).trim();
+    return input
+        .replace(/\\/g, path.sep)
+        .trim()
+        .replace(new RegExp(`${path.sep}$`), '');
 }
 
 function isGlobExpression(input: string): boolean {


### PR DESCRIPTION
Fixes #239

(It's not clear if this is actually the same issue as #239, but this change fixes it for me on MacOS.)

The error message is:

```console
Element with id /Users/REDACTED/Projects/REDACTED/REDACTED/REDACTED.sln[solution]-REDACTED.CLI[project]-Properties[project-folder] is already registered
```

The project could not be expanded because there are multiple folder items with the same id.

In my case I had these two folders with the same id:

- `Properties`
- `Properties/`

This can happen when you explicitly include a folder with a trailing slash in your .csproj, for example:

```xml
<ItemGroup>
	<Folder Include="Properties\" />
</ItemGroup>
```