### PR TITLE
Support case sensitive file systems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-solution-explorer",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2275,6 +2275,11 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
+        },
+        "true-case-path": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
+            "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
         },
         "ts-loader": {
             "version": "9.3.1",

--- a/package.json
+++ b/package.json
@@ -1664,6 +1664,7 @@
         "eol": "^0.9.1",
         "handlebars": "^4.7.7",
         "node-fetch": "^3.2.10",
+        "true-case-path": "^2.2.1",
         "uuid": "^8.3.2",
         "xml-js": "^1.6.11"
     }

--- a/src/extensions/fs.ts
+++ b/src/extensions/fs.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { trueCasePath } from 'true-case-path';
 
 export async function copy(sourcePath: string, targetPath: string): Promise<void> {
     const sourceUri = vscode.Uri.file(sourcePath);
@@ -7,10 +8,9 @@ export async function copy(sourcePath: string, targetPath: string): Promise<void
 }
 
 export async function exists(path: string): Promise<boolean> {
-    const uri = vscode.Uri.file(path);
     try {
-        await vscode.workspace.fs.stat(uri);
-        return true;
+        const caseCorrectPath = await trueCasePath(path);
+        return caseCorrectPath === path;
     } catch (e) {
         return false;
     }


### PR DESCRIPTION
Fixes #238 

Neither Node.js nor the VSCode API's support case sensitive file system by default.

I went back on forth on different approaches to handle this but in the end decided to just use a package: [true-case-path](https://www.npmjs.com/package/true-case-path)

Tested on MacOS. I can rename folders and files by just changing the case.