### PR TITLE
Update single package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,11 @@
                 "icon": "$(add)"
             },
             {
+                "command": "solutionExplorer.updatePackageVersion",
+                "title": "Update package version",
+                "category": "Solution Explorer"
+            },
+            {
                 "command": "solutionExplorer.removePackage",
                 "title": "Remove package",
                 "category": "Solution Explorer",
@@ -480,6 +485,11 @@
                     "command": "solutionExplorer.addPackage",
                     "when": "view == slnexpl && viewItem == project-referenced-packages-cps",
                     "group": "inline"
+                },
+                {
+                    "command": "solutionExplorer.updatePackageVersion",
+                    "when": "view == slnexpl && viewItem == project-referenced-package-cps",
+                    "group": "2_workspace"
                 },
                 {
                     "command": "solutionExplorer.removePackage",
@@ -895,6 +905,11 @@
                     "command": "solutionExplorer.addPackage",
                     "when": "view == slnbrw && viewItem == project-referenced-packages-cps",
                     "group": "inline"
+                },
+                {
+                    "command": "solutionExplorer.updatePackageVersion",
+                    "when": "view == slnbrw && viewItem == project-referenced-package-cps",
+                    "group": "2_workspace"
                 },
                 {
                     "command": "solutionExplorer.removePackage",

--- a/src/SolutionExplorerCommands.ts
+++ b/src/SolutionExplorerCommands.ts
@@ -17,6 +17,7 @@ export class SolutionExplorerCommands {
         this.commands['addExistingProject'] = new cmds.AddExistingProjectCommand(provider);
         this.commands['addNewProject'] = new cmds.AddNewProjectCommand(provider);
         this.commands['addPackage'] = new cmds.AddPackageCommand();
+        this.commands['updatePackageVersion'] = new cmds.UpdatePackageVersionCommand();
         this.commands['addProjectReference'] = new cmds.AddProjectReferenceCommand();
         this.commands['addSolutionFile'] = new cmds.AddExistingFileToSolutionFolderCommand();
         this.commands['build'] = new cmds.BuildCommand();

--- a/src/commands/UpdatePackageVersionCommand.ts
+++ b/src/commands/UpdatePackageVersionCommand.ts
@@ -1,0 +1,87 @@
+import * as dialogs from '@extensions/dialogs';
+import * as nuget from '@extensions/nuget';
+import { ContextValues, TreeItem } from "@tree";
+import { Action, AddPackageReference } from "@actions";
+import { ActionsCommand } from "@commands";
+
+export class UpdatePackageVersionCommand extends ActionsCommand {
+    private nugetFeeds: nuget.NugetFeed[] = [];
+    private lastNugetPackages: nuget.NugetPackage[] = [];
+    private wizard: dialogs.Wizard | undefined;
+    constructor() {
+        super('Update Package Version');
+    }
+
+    public  shouldRun(item: TreeItem): boolean {
+        return !!item && !!item.project && !!item.path && item.contextValue === ContextValues.projectReferencedPackage + '-cps';
+    }
+
+    public async getActions(item: TreeItem): Promise<Action[]> {
+        if (!item || !item.project || !item.path) { return []; }
+
+        const projectFullPath = item.project.fullPath;
+        const packageId = item.path;
+        this.wizard = new dialogs.Wizard('Update package version')
+                                 .selectOption('Select a feed', () => this.getNugetFeeds(projectFullPath) )
+                                 .selectOption('Select a version', 
+                                    () => this.getCurrentPackageVersions(packageId),
+                                    () => this.getCurrentPackageDefaultVersion(packageId)
+                                );
+
+        const parameters = await this.wizard.run();
+        if (!parameters) {
+            return [];
+        }
+
+        return [ new AddPackageReference(item.project.fullPath, packageId, parameters[1]) ];
+    }
+
+    private async getNugetFeeds(projectFullPath: string): Promise<string[]> {
+        this.nugetFeeds = await nuget.getNugetFeeds(projectFullPath);
+        if (this.nugetFeeds.length === 0) {
+            const defaultNugetFeed = await nuget.getDefaultNugetFeed();
+            this.nugetFeeds = [ defaultNugetFeed ];
+        }
+
+        return this.nugetFeeds.map(f => f.name);
+    }
+
+    private async searchAndMapNugetPackages(packageId: string): Promise<string[]> {
+        if (!this.wizard || !this.wizard.context || !this.wizard.context.results) {
+            return [];
+        }
+
+        const feedName = this.wizard.context.results[0];
+        const feed = this.nugetFeeds.find(f => f.name === feedName);
+        if (!feed) { return []; }
+
+        this.lastNugetPackages = await nuget.searchNugetPackage(feed, packageId);
+        return this.lastNugetPackages.map(p => p.id);
+    }
+
+    private async getCurrentPackageVersions(packageId: string): Promise<string[]> {
+        if (this.lastNugetPackages.length === 0) {
+            await this.searchAndMapNugetPackages(packageId);
+        }
+
+        const nugetPackage = this.lastNugetPackages.find(p => p.id === packageId);
+        if (!nugetPackage) {
+            return Promise.resolve([]);
+        }
+
+        return Promise.resolve(nugetPackage.versions.map(v => v.version).reverse());
+    }
+
+    private async getCurrentPackageDefaultVersion(packageId: string): Promise<string> {
+        if (this.lastNugetPackages.length === 0) {
+            await this.searchAndMapNugetPackages(packageId);
+        }
+
+        const nugetPackage = this.lastNugetPackages.find(p => p.id === packageId);
+        if (!nugetPackage) {
+            return Promise.resolve("");
+        }
+
+        return Promise.resolve(nugetPackage.version);
+    }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -37,3 +37,4 @@ export * from "./SelectActiveDocumentCommand";
 export * from "./TestCommand";
 export * from "./UpdatePackagesVersionCommand";
 export * from "./WatchRunCommand";
+export * from "./UpdatePackageVersionCommand";


### PR DESCRIPTION
Fixes #242

This PR adds a new command "Update package version" which is used to update a single package.

A new context menu option is added to the package preferences:

<img width="440" alt="Screenshot 2022-12-17 at 12 15 34" src="https://user-images.githubusercontent.com/102141/208241492-0e0027e5-61c0-4dd3-905f-0c69155f4daa.png">

This takes you through a wizard which is very similar to the AddPackage wizard:
<img width="725" alt="Screenshot 2022-12-17 at 12 15 50" src="https://user-images.githubusercontent.com/102141/208241505-6d106bf9-8ef1-4fa5-b131-c10f52d24403.png">

<img width="737" alt="Screenshot 2022-12-17 at 12 15 59" src="https://user-images.githubusercontent.com/102141/208241509-cddf02ee-bd2d-463a-adf5-3e5f96e93318.png">

Once the version is selected the `AddPackageReference` action is used to run the `addPackageReferenceToProjectWithVersion` cli command.