### PR TITLE
Show nested package references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-solution-explorer",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -605,6 +605,11 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true
+        },
+        "at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
         },
         "balanced-match": {
             "version": "1.0.0",
@@ -1219,6 +1224,14 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "fast-xml-parser": {
+            "version": "3.21.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+            "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+            "requires": {
+                "strnum": "^1.0.4"
+            }
+        },
         "fastest-levenshtein": {
             "version": "1.0.16",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -1290,6 +1303,17 @@
             "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
             "requires": {
                 "fetch-blob": "^3.1.2"
+            }
+        },
+        "fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             }
         },
         "fs.realpath": {
@@ -1377,8 +1401,7 @@
         "graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-            "dev": true
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         },
         "grapheme-splitter": {
             "version": "1.0.4",
@@ -1578,6 +1601,15 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
+        "jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+            }
+        },
         "kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -1609,11 +1641,21 @@
                 "p-locate": "^5.0.0"
             }
         },
+        "lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
+        },
+        "loglevel": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+            "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg=="
         },
         "lru-cache": {
             "version": "6.0.0",
@@ -1857,6 +1899,19 @@
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "requires": {
                 "path-key": "^3.0.0"
+            }
+        },
+        "nuget-deps-tree": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/nuget-deps-tree/-/nuget-deps-tree-0.2.2.tgz",
+            "integrity": "sha512-54UcW0vlzi92DcJfOnx8RyKaY89leSERzHi+h9r0IpYN4GqjDG5Un3S8RKMAws+WOPExnrU7/YjKgOq6+EyxrA==",
+            "requires": {
+                "fast-xml-parser": "^3.17.4",
+                "fs-extra": "^9.0.1",
+                "lodash": "^4.17.21",
+                "loglevel": "^1.7.1",
+                "walkdir": "^0.4.1",
+                "which": "^2.0.2"
             }
         },
         "once": {
@@ -2235,6 +2290,11 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
+        "strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+        },
         "supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -2434,6 +2494,11 @@
             "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
             "optional": true
         },
+        "universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        },
         "uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2453,6 +2518,11 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
             "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
             "dev": true
+        },
+        "walkdir": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+            "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ=="
         },
         "watchpack": {
             "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -1664,6 +1664,7 @@
         "eol": "^0.9.1",
         "handlebars": "^4.7.7",
         "node-fetch": "^3.2.10",
+        "nuget-deps-tree": "0.2.2",
         "uuid": "^8.3.2",
         "xml-js": "^1.6.11"
     }

--- a/src/core/Projects/MsBuildProject.ts
+++ b/src/core/Projects/MsBuildProject.ts
@@ -1,3 +1,4 @@
+import { Project as NugetProject } from 'nuget-deps-tree/dist/src/Structure/OutputStructure';
 import * as fs from "@extensions/fs";
 import * as path from "@extensions/path";
 import * as config from "@extensions/config";
@@ -10,7 +11,7 @@ export class MsBuildProject extends ProjectWithManagers {
     private packagesReferenges: PackageReference[] = [];
     private projectItemEntries: ProjectItemEntry[] = [];
 
-    constructor(projectFullPath: string, withReferences?: boolean, includePrefix?: string) {
+    constructor(projectFullPath: string, withReferences?: boolean, includePrefix?: string, private nugetPackagesDependencyTree?: NugetProject) {
         super(projectFullPath, withReferences, includePrefix);
     }
 
@@ -29,6 +30,10 @@ export class MsBuildProject extends ProjectWithManagers {
         this.projectItemEntries = [];
         await super.refresh();
         await this.checkProjectLoaded();
+    }
+
+    public getNugetPackagesDependencyTree(): NugetProject | undefined {
+        return this.nugetPackagesDependencyTree;
     }
 
     public async getReferences(): Promise<Reference[]> {

--- a/src/core/Projects/Project.ts
+++ b/src/core/Projects/Project.ts
@@ -1,3 +1,4 @@
+import { Project as NugetProject } from 'nuget-deps-tree/dist/src/Structure/OutputStructure';
 import * as path from "@extensions/path";
 import { PackageReference, ProjectItemEntry, ProjectReference, Reference } from "./Items";
 import { ProjectFileStat } from "./ProjectFileStat";
@@ -33,6 +34,8 @@ export abstract class Project {
     public abstract getProjectReferences(): Promise<ProjectReference[]>;
 
     public abstract getPackageReferences(): Promise<PackageReference[]>;
+
+    public abstract getNugetPackagesDependencyTree(): NugetProject | undefined;
 
     public abstract getProjectItemEntries(): Promise<ProjectItemEntry[]>;
 

--- a/src/core/Projects/ProjectFactory.ts
+++ b/src/core/Projects/ProjectFactory.ts
@@ -1,3 +1,4 @@
+import { Project as NugetProject } from 'nuget-deps-tree/dist/src/Structure/OutputStructure';
 import * as path from "@extensions/path";
 import * as fs from "@extensions/fs";
 import { ProjectInSolution, SolutionProjectType, ProjectTypeIds } from "../Solutions";
@@ -58,19 +59,19 @@ export class ProjectFactory {
 
     private static loadProjectByType(project: ProjectInSolution): Project | undefined {
         if (project.projectType === SolutionProjectType.knownToBeMSBuildFormat) {
-            return ProjectFactory.loadDefaultProject(project.fullPath);
+            return ProjectFactory.loadDefaultProject(project.fullPath, project.nugetPackagesDependencyTree);
         }
 
         if (project.projectType === SolutionProjectType.webProject) {
-            return ProjectFactory.loadDefaultProject(project.fullPath);
+            return ProjectFactory.loadDefaultProject(project.fullPath, project.nugetPackagesDependencyTree);
         }
 
         if (project.projectTypeId === ProjectTypeIds.shProjectGuid) {
-            return ProjectFactory.loadSharedProject(project.fullPath);
+            return ProjectFactory.loadSharedProject(project.fullPath, project.nugetPackagesDependencyTree);
         }
 
         if (project.projectTypeId === ProjectTypeIds.deployProjectGuid) {
-            return ProjectFactory.loadNoReferencesProject(project.fullPath);
+            return ProjectFactory.loadNoReferencesProject(project.fullPath, project.nugetPackagesDependencyTree);
         }
     }
 
@@ -85,15 +86,15 @@ export class ProjectFactory {
         }
     }
 
-    private static loadDefaultProject(fullPath: string): Project {
-        return new MsBuildProject(fullPath);
+    private static loadDefaultProject(fullPath: string, nugetPackagesDependencyTree?: NugetProject): Project {
+        return new MsBuildProject(fullPath, undefined, undefined, nugetPackagesDependencyTree);
     }
 
-    private static loadNoReferencesProject(fullPath: string): Project {
-        return new MsBuildProject(fullPath, false);
+    private static loadNoReferencesProject(fullPath: string, nugetPackagesDependencyTree?: NugetProject): Project {
+        return new MsBuildProject(fullPath, false, undefined, nugetPackagesDependencyTree);
     }
 
-    private static loadSharedProject(fullPath: string): Project {
-        return new MsBuildProject(fullPath.replace(".shproj", ".projitems"), false, "$(MSBuildThisFileDirectory)");
+    private static loadSharedProject(fullPath: string, nugetPackagesDependencyTree?: NugetProject): Project {
+        return new MsBuildProject(fullPath.replace(".shproj", ".projitems"), false, "$(MSBuildThisFileDirectory)", nugetPackagesDependencyTree);
     }
 }

--- a/src/core/Solutions/ProjectInSolution.ts
+++ b/src/core/Solutions/ProjectInSolution.ts
@@ -6,6 +6,7 @@
 import { SolutionFile } from "./SolutionFile";
 import { SolutionProjectType } from "./SolutionProjectType";
 import { ProjectConfigurationInSolution } from "./ProjectConfigurationInSolution";
+import { Project as NugetProject } from 'nuget-deps-tree/dist/src/Structure/OutputStructure';
 
 export class ProjectInSolution {
     constructor(public readonly solution: SolutionFile) {
@@ -22,9 +23,14 @@ export class ProjectInSolution {
     public webProperties: { [id: string] : string } = {};
     public configuration: { [id: string] : ProjectConfigurationInSolution } = {};
     public solutionItems: { [id: string] : string } = {};
+    public nugetPackagesDependencyTree: NugetProject | undefined;
 
     public addDependency(parentGuid: string): void {
         this.dependencies.push(parentGuid);
+    }
+
+    public addNugetPackagesDependencyTree(nugetPackagesDependencyTree: NugetProject): void {
+        this.nugetPackagesDependencyTree = nugetPackagesDependencyTree;
     }
 
     public addWebProperty(name: string, value: string): void {

--- a/src/tree/ContextValues.ts
+++ b/src/tree/ContextValues.ts
@@ -8,6 +8,7 @@ export class ContextValues {
     public static readonly projectReferencedProject: string = 'project-referenced-project';
     public static readonly projectReferencedPackages: string = 'project-referenced-packages';
     public static readonly projectReferencedPackage: string = 'project-referenced-package';
+    public static readonly projectReferencedPackageTransitive: string = 'project-referenced-package-transitive';
     public static readonly projectFolder: string = 'project-folder';
     public static readonly projectFile: string = 'project-file';
     public static readonly error: string = 'error';

--- a/src/tree/TreeItem.ts
+++ b/src/tree/TreeItem.ts
@@ -155,6 +155,7 @@ export abstract class TreeItem extends vscode.TreeItem {
 	protected loadResourceUri(): void {
 		const ignoreTypes = [
 			ContextValues.projectReferencedPackage,
+			ContextValues.projectReferencedPackageTransitive,
 			ContextValues.projectReferencedPackages,
 			ContextValues.projectReferencedProject,
 			ContextValues.projectReferencedProjects,

--- a/src/tree/items/ProjectReferencedPackageTreeItem.ts
+++ b/src/tree/items/ProjectReferencedPackageTreeItem.ts
@@ -1,12 +1,39 @@
+import { DependencyTree } from 'nuget-deps-tree/dist/src/DependencyTree/Tree';
+
 import { PackageReference } from "@core/Projects";
 import { TreeItem, TreeItemCollapsibleState, TreeItemContext, ContextValues } from "@tree";
 
 export class ProjectReferencedPackageTreeItem extends TreeItem {
-    constructor(context: TreeItemContext, pkgRef: PackageReference) {
-        super(context, pkgRef.name, TreeItemCollapsibleState.None, ContextValues.projectReferencedPackage, pkgRef.name);
+    constructor(context: TreeItemContext, private pkgRef: PackageReference, private projectNugetDeps: DependencyTree[], contextValue: string = ContextValues.projectReferencedPackage) {
+        super(
+            context,
+            pkgRef.name,
+            projectNugetDeps.length > 0 ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None,
+            contextValue,
+            pkgRef.name
+        );
         this.description = pkgRef.version;
         this.allowIconTheme = false;
         this.addContextValueSuffix();
+    }
+
+    protected async createChildren(childContext: TreeItemContext): Promise<TreeItem[]> {
+        let result: TreeItem[] = [];
+        const newContext = this.context.copy(this.context.project, this);
+        if (newContext.parent) {
+            newContext.parent.id = newContext.parent.id + this.pkgRef.name;
+        }
+        this.projectNugetDeps.forEach((p) => {
+            result.push(
+                new ProjectReferencedPackageTreeItem(
+                    newContext,
+                    new PackageReference(p.id, p.version),
+                    p.dependencies,
+                    ContextValues.projectReferencedPackageTransitive
+                )
+            );
+        });
+        return result;
     }
 
     protected loadThemeIcon(fullpath: string): void {

--- a/src/tree/items/ProjectReferencedPackagesTreeItem.ts
+++ b/src/tree/items/ProjectReferencedPackagesTreeItem.ts
@@ -35,7 +35,10 @@ export class ProjectReferencedPackagesTreeItem extends TreeItem {
     }
 
     protected createReferencePackageItem(childContext: TreeItemContext, ref: PackageReference) {
-        return new ProjectReferencedPackageTreeItem(childContext, ref);
+        const deps = (this.context.project?.getNugetPackagesDependencyTree()?.dependencies || [])
+            .find(d => d.id === ref.name)
+            ?.dependencies || []
+        return new ProjectReferencedPackageTreeItem(childContext, ref, deps);
     }
 
     protected loadThemeIcon(fullpath: string): void {


### PR DESCRIPTION
Fixes #235

We still list the top-level packages based on the package definitions within the .csproj file, but nested packages are discovered using the [`nuget-deps-tree`](https://www.npmjs.com/package/nuget-deps-tree) package. That package parses the `project.assets.json` file. After doing some research, this seems like the easiest approach to provide a nested package tree for nuget packages. The `project.assets.json` file should exist for dotnet core projects. 

This should be non-breaking, in that if the `nuget-deps-tree` package has any problems discovering nuget packages, then no nested package deps are displayed (but the top-level packages are still displayed).


https://user-images.githubusercontent.com/102141/208253522-8dc70204-328f-4afc-9799-28ad80c5838d.mov

