### PR TITLE
Fixed a bug when using "Inlcude" project items.

### DIFF
--- a/src/core/Projects/Items/Include.ts
+++ b/src/core/Projects/Items/Include.ts
@@ -16,7 +16,7 @@ export class Include extends IncludeBase {
             const searchPath = glob.isGlobPattern(pattern) ? path.join(projectBasePath, internalPath) : projectBasePath;
             const result = await glob.globFileSearch(searchPath, this.cleanPathDownAtStart(pattern), this.exclude ? this.exclude?.split(';') : undefined);
             for (const filepath of result) {
-                const recursiveDir = this.getRecursiveDir(filepath, searchPath);
+                const recursiveDir = this.getRecursiveDir(filepath, projectBasePath);
                 const relativePath = this.getRelativePath(filepath, recursiveDir);
                 const isLink = !filepath.startsWith(projectBasePath);
                 const folderEntries: ProjectItemEntry[] = this.createFoldersIfNotExists(entries, relativePath, filepath, isLink);


### PR DESCRIPTION
To reproduce the bug, you will need to add a configuration in your csproj file, similar to following:
```
<ItemGroup>
    <!-- Don't publish the ClientApp source files, but do show them in the project files list -->
    <Content Remove="ClientApp\**" />
    <None Remove="ClientApp\**" />
    <None Include="ClientApp\**" Exclude="ClientApp\node_modules\**" />
</ItemGroup>
```
You will also need a folder named ClientApp in your project containing folders and/or files. The problem is, when you open this project with solution explorer, ClientApp directory will appear to be empty, regardless of what files and folders it contains in reality. It looks like this is because the wrong "relative file path" is computed when parsing the csproj file.

There are 3 cases when parsing the Include:
1. It doesn't contain a glob.
2. It contains a glob, but the is no "internal path".
3. It contains a glob, which also has an "internal path".

This PR should change the behavior of the 3rd case, while leaving the other 2 cases unchanged. In the 3rd case, the "relative file path" seems to be wrong. I didn't find any relevant issue in github by the way.