### PR TITLE
Fixed issue #5 - keyboard shortcuts not working.

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,6 +290,11 @@
                 "command": "solutionExplorer.showActiveFileInExplorer",
                 "title": "Select Active Document",
                 "category": "Solution Explorer"
+            },
+            {
+                "command": "solutionExplorer.executeMultipleCommands",
+                "title": "Combines multiple commands into one (meant for use with keybindings)",
+                "category": "Solution Explorer"
             }
         ],
         "menus": {
@@ -1160,364 +1165,239 @@
         },
         "keybindings": [
             {
-                "command": "solutionExplorer.copy",
-                "when": "view == slnexpl && viewItem == project-folder",
+                "command": "solutionExplorer.executeMultipleCommands",
                 "key": "ctrl+c",
-                "mac": "cmd+c"
+                "mac": "cmd+c",
+                "when": "focusedView == slnexpl || focusedView == slnbrw",
+                "args": [
+                    [
+                        "solutionExplorer.copy",
+                        {
+                            "requiredViewItem": "project-folder"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.copy",
+                        {
+                            "requiredViewItem": "project-file"
+                        }
+                    ]
+                ]
             },
             {
-                "command": "solutionExplorer.copy",
-                "when": "view == slnexpl && viewItem == project-file",
-                "key": "ctrl+c",
-                "mac": "cmd+c"
-            },
-            {
-                "command": "solutionExplorer.paste",
-                "when": "view == slnexpl && viewItem == project-folder",
+                "command": "solutionExplorer.executeMultipleCommands",
                 "key": "ctrl+v",
-                "mac": "cmd+v"
+                "mac": "cmd+v",
+                "when": "focusedView == slnexpl || focusedView == slnbrw",
+                "args": [
+                    [
+                        "solutionExplorer.paste",
+                        {
+                            "requiredViewItem": "project-folder"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.paste",
+                        {
+                            "requiredViewItem": "project-cps"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.paste",
+                        {
+                            "requiredViewItem": "project-standard"
+                        }
+                    ]
+                ]
             },
             {
-                "command": "solutionExplorer.paste",
-                "when": "view == slnexpl && viewItem == project-cps",
-                "key": "ctrl+v",
-                "mac": "cmd+v"
-            },
-            {
-                "command": "solutionExplorer.paste",
-                "when": "view == slnexpl && viewItem == project-standard",
-                "key": "ctrl+v",
-                "mac": "cmd+v"
-            },
-            {
-                "command": "solutionExplorer.renameFile",
-                "when": "view == slnexpl && viewItem == project-file",
+                "command": "solutionExplorer.executeMultipleCommands",
                 "key": "f2",
-                "mac": "f2"
+                "mac": "f2",
+                "when": "focusedView == slnexpl || focusedView == slnbrw",
+                "args": [
+                    [
+                        "solutionExplorer.renameFile",
+                        {
+                            "requiredViewItem": "project-file"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.renameFolder",
+                        {
+                            "requiredViewItem": "project-folder"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.renameSolutionItem",
+                        {
+                            "requiredViewItem": "solution"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.renameSolutionItem",
+                        {
+                            "requiredViewItem": "solution-cps"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.renameSolutionItem",
+                        {
+                            "requiredViewItem": "solution-folder"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.renameSolutionItem",
+                        {
+                            "requiredViewItem": "project-cps"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.renameSolutionItem",
+                        {
+                            "requiredViewItem": "project-standard"
+                        }
+                    ]
+                ]
             },
             {
-                "command": "solutionExplorer.deleteFile",
-                "when": "view == slnexpl && viewItem == project-file",
+                "command": "solutionExplorer.executeMultipleCommands",
                 "key": "delete",
-                "mac": "delete"
+                "mac": "delete",
+                "when": "focusedView == slnexpl || focusedView == slnbrw",
+                "args": [
+                    [
+                        "solutionExplorer.deleteFile",
+                        {
+                            "requiredViewItem": "project-file",
+							"useMultipleSelection": true
+                        }
+                    ],
+                    [
+                        "solutionExplorer.deleteFolder",
+                        {
+                            "requiredViewItem": "project-folder",
+							"useMultipleSelection": true
+                        }
+                    ],
+                    [
+                        "solutionExplorer.removePackage",
+                        {
+                            "requiredViewItem": "project-referenced-package-cps",
+							"useMultipleSelection": true
+                        }
+                    ],
+                    [
+                        "solutionExplorer.removeProjectReference",
+                        {
+                            "requiredViewItem": "project-referenced-project-cps",
+							"useMultipleSelection": true
+                        }
+                    ],
+                    [
+                        "solutionExplorer.removeSolutionFolder",
+                        {
+                            "requiredViewItem": "solution-folder",
+							"useMultipleSelection": true
+                        }
+                    ],
+                    [
+                        "solutionExplorer.removeProject",
+                        {
+                            "requiredViewItem": "project-cps",
+							"useMultipleSelection": true
+                        }
+                    ],
+                    [
+                        "solutionExplorer.removeProject",
+                        {
+                            "requiredViewItem": "project-standard",
+							"useMultipleSelection": true
+                        }
+                    ]
+                ]
             },
             {
-                "command": "solutionExplorer.renameFolder",
-                "when": "view == slnexpl && viewItem == project-folder",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.deleteFolder",
-                "when": "view == slnexpl && viewItem == project-folder",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.createFile",
-                "when": "view == slnexpl && viewItem == project-cps",
+                "command": "solutionExplorer.executeMultipleCommands",
                 "key": "ctrl+shift+a",
-                "mac": "cmd+shift+a"
+                "mac": "cmd+shift+a",
+                "when": "focusedView == slnexpl || focusedView == slnbrw",
+                "args": [
+                    [
+                        "solutionExplorer.createFile",
+                        {
+                            "requiredViewItem": "project-cps"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.createFile",
+                        {
+                            "requiredViewItem": "project-standard"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.createFile",
+                        {
+                            "requiredViewItem": "project-file"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.createFile",
+                        {
+                            "requiredViewItem": "project-folder"
+                        }
+                    ]
+                ]
             },
             {
-                "command": "solutionExplorer.createFile",
-                "when": "view == slnexpl && viewItem == project-standard",
-                "key": "ctrl+shift+a",
-                "mac": "cmd+shift+a"
-            },
-            {
-                "command": "solutionExplorer.createFile",
-                "when": "view == slnexpl && viewItem == project-file",
-                "key": "ctrl+shift+a",
-                "mac": "cmd+shift+a"
-            },
-            {
-                "command": "solutionExplorer.createFile",
-                "when": "view == slnexpl && viewItem == project-folder",
-                "key": "ctrl+shift+a",
-                "mac": "cmd+shift+a"
-            },
-            {
-                "command": "solutionExplorer.createFolder",
-                "when": "view == slnexpl && viewItem == project-cps",
+                "command": "solutionExplorer.executeMultipleCommands",
                 "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.createFolder",
-                "when": "view == slnexpl && viewItem == project-standard",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.createFolder",
-                "when": "view == slnexpl && viewItem == project-file",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.createFolder",
-                "when": "view == slnexpl && viewItem == project-folder",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.removePackage",
-                "when": "view == slnexpl && viewItem == project-referenced-package-cps",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.removeProjectReference",
-                "when": "view == slnexpl && viewItem == project-referenced-project-cps",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.createSolutionFolder",
-                "when": "view == slnexpl && viewItem == solution",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.createSolutionFolder",
-                "when": "view == slnexpl && viewItem == solution-cps",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.createSolutionFolder",
-                "when": "view == slnexpl && viewItem == solution-folder",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.removeSolutionFolder",
-                "when": "view == slnexpl && viewItem == solution-folder",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.removeProject",
-                "when": "view == slnexpl && viewItem == project-cps",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.removeProject",
-                "when": "view == slnexpl && viewItem == project-standard",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.renameSolutionItem",
-                "when": "view == slnexpl && viewItem == solution",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.renameSolutionItem",
-                "when": "view == slnexpl && viewItem == solution-cps",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.renameSolutionItem",
-                "when": "view == slnexpl && viewItem == solution-folder",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.renameSolutionItem",
-                "when": "view == slnexpl && viewItem == project-cps",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.renameSolutionItem",
-                "when": "view == slnexpl && viewItem == project-standard",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.copy",
-                "when": "view == slnbrw && viewItem == project-folder",
-                "key": "ctrl+c",
-                "mac": "cmd+c"
-            },
-            {
-                "command": "solutionExplorer.copy",
-                "when": "view == slnbrw && viewItem == project-file",
-                "key": "ctrl+c",
-                "mac": "cmd+c"
-            },
-            {
-                "command": "solutionExplorer.paste",
-                "when": "view == slnbrw && viewItem == project-folder",
-                "key": "ctrl+v",
-                "mac": "cmd+v"
-            },
-            {
-                "command": "solutionExplorer.paste",
-                "when": "view == slnbrw && viewItem == project-cps",
-                "key": "ctrl+v",
-                "mac": "cmd+v"
-            },
-            {
-                "command": "solutionExplorer.paste",
-                "when": "view == slnbrw && viewItem == project-standard",
-                "key": "ctrl+v",
-                "mac": "cmd+v"
-            },
-            {
-                "command": "solutionExplorer.renameFile",
-                "when": "view == slnbrw && viewItem == project-file",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.deleteFile",
-                "when": "view == slnbrw && viewItem == project-file",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.renameFolder",
-                "when": "view == slnbrw && viewItem == project-folder",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.deleteFolder",
-                "when": "view == slnbrw && viewItem == project-folder",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.createFile",
-                "when": "view == slnbrw && viewItem == project-cps",
-                "key": "ctrl+shift+a",
-                "mac": "cmd+shift+a"
-            },
-            {
-                "command": "solutionExplorer.createFile",
-                "when": "view == slnbrw && viewItem == project-standard",
-                "key": "ctrl+shift+a",
-                "mac": "cmd+shift+a"
-            },
-            {
-                "command": "solutionExplorer.createFile",
-                "when": "view == slnbrw && viewItem == project-file",
-                "key": "ctrl+shift+a",
-                "mac": "cmd+shift+a"
-            },
-            {
-                "command": "solutionExplorer.createFile",
-                "when": "view == slnbrw && viewItem == project-folder",
-                "key": "ctrl+shift+a",
-                "mac": "cmd+shift+a"
-            },
-            {
-                "command": "solutionExplorer.createFolder",
-                "when": "view == slnbrw && viewItem == project-cps",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.createFolder",
-                "when": "view == slnbrw && viewItem == project-standard",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.createFolder",
-                "when": "view == slnbrw && viewItem == project-file",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.createFolder",
-                "when": "view == slnbrw && viewItem == project-folder",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.removePackage",
-                "when": "view == slnbrw && viewItem == project-referenced-package-cps",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.removeProjectReference",
-                "when": "view == slnbrw && viewItem == project-referenced-project-cps",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.createSolutionFolder",
-                "when": "view == slnbrw && viewItem == solution",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.createSolutionFolder",
-                "when": "view == slnbrw && viewItem == solution-cps",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.createSolutionFolder",
-                "when": "view == slnbrw && viewItem == solution-folder",
-                "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f"
-            },
-            {
-                "command": "solutionExplorer.removeSolutionFolder",
-                "when": "view == slnbrw && viewItem == solution-folder",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.removeProject",
-                "when": "view == slnbrw && viewItem == project-cps",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.removeProject",
-                "when": "view == slnbrw && viewItem == project-standard",
-                "key": "delete",
-                "mac": "delete"
-            },
-            {
-                "command": "solutionExplorer.renameSolutionItem",
-                "when": "view == slnbrw && viewItem == solution",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.renameSolutionItem",
-                "when": "view == slnbrw && viewItem == solution-cps",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.renameSolutionItem",
-                "when": "view == slnbrw && viewItem == solution-folder",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.renameSolutionItem",
-                "when": "view == slnbrw && viewItem == project-cps",
-                "key": "f2",
-                "mac": "f2"
-            },
-            {
-                "command": "solutionExplorer.renameSolutionItem",
-                "when": "view == slnbrw && viewItem == project-standard",
-                "key": "f2",
-                "mac": "f2"
+                "mac": "cmd+shift+f",
+                "when": "focusedView == slnexpl || focusedView == slnbrw",
+                "args": [
+                    [
+                        "solutionExplorer.createFolder",
+                        {
+                            "requiredViewItem": "project-cps"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.createFolder",
+                        {
+                            "requiredViewItem": "project-standard"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.createFolder",
+                        {
+                            "requiredViewItem": "project-file"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.createFolder",
+                        {
+                            "requiredViewItem": "project-folder"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.createSolutionFolder",
+                        {
+                            "requiredViewItem": "solution"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.createSolutionFolder",
+                        {
+                            "requiredViewItem": "solution-cps"
+                        }
+                    ],
+                    [
+                        "solutionExplorer.createSolutionFolder",
+                        {
+                            "requiredViewItem": "solution-folder"
+                        }
+                    ]
+                ]
             }
         ],
         "configuration": {

--- a/src/SolutionExplorerProvider.ts
+++ b/src/SolutionExplorerProvider.ts
@@ -115,6 +115,11 @@ export class SolutionExplorerProvider extends vscode.Disposable implements vscod
 		return element.parent;
 	}
 
+	public getSelectedTreeItems(): readonly sln.TreeItem[] | undefined {
+
+		return this.treeView?.selection;
+	}
+
 	public async selectFile(filepath: string): Promise<void> {
 		if (!this.solutionTreeItemCollection.hasChildren) { return; }
 		for(let i = 0; i < this.solutionTreeItemCollection.length; i++) {


### PR DESCRIPTION
There were three problems:
1. For some reason, key bindings need to check for the "focusedView" instead of the "view" in their "when" clauses.
2. The check for "viewItem" has to be completely removed from "when" clauses.
3. Command handlers aren't given a TreeItem when the command runs form a keybinding. An alternative way to get the current selection is needed. 

https://github.com/microsoft/vscode/issues/72442 confirms what I found out. It looks like VSCode doesn't associate key press events with the selected tree items currently. That's why the context menu works but shortcuts don't.

The solution is to get the selected TreeItem directly from the treeview. This has the advantage that you can also get all selected items if needed (e.g. the Delete command should delete all selected items instead of one). As for checking the view item type, this can be done inside the command handler's code. I opted for passing the required view item type as an argument of the key binding's command to minimize changes in the code, but it could have been hardcoded in each command instead.

Since the "when" clauses became the same for some commands after removing "viewItem", only the last registered command would be executed. So the next step was to combine all commands into one for each key.  I added a helper command that accepts a list of commands and their arguments to do this, in order to minimize changes in the code.

In addition, this PR updates the "Delete" command to run for all selected files instead of the last selected file. As a result of the implementation, when deleting multiple files the user will be asked whether they are sure they want to delete each file separately. To address this problem, a new delete command that unifies existing delete commands can be added.

Another side effect of this PR is that the key bindings will not be visible in the context menu (since they don't run the same command anymore). It looks like this problem can be addressed if all commands are "unified". For example, currently there are 3 different types of rename commands.

In conclusion this PR will work, but I feel it isn't complete. So let me know whether you would like me to add the "unified" commands I suggested. In which case, would you prefer to keep existing commands (and end up with 4 rename commands for example) or simply merging them into one? Do you prefer the required view item of each command to be hardcoded or to keep it in package.json?

I just want some feedback from you before I try to refactor more code.