### PR TITLE
Refresh tree view item icons properly

### DIFF
--- a/src/tree/TreeItem.ts
+++ b/src/tree/TreeItem.ts
@@ -140,6 +140,7 @@ export abstract class TreeItem extends vscode.TreeItem {
 			TreeItemIconProvider.findIconPath(this.label, this.path || "", this.contextValue)
 			                    .then( iconPath => {
 									this.iconPath = iconPath;
+									this.context.provider.refresh(this);
 								});
 		} else {
 			let fullpath = this.path;


### PR DESCRIPTION
When using "solution-explorer" icons, this fixes:
1. Some projects that incorrectly used the folder icon. This seems to happen randomly for some projects, possibly depending on the time it takes to load the solution. The commit message says expanding/loading the project would load the correct icon, but it turns out this doesn't work for some projects.
2. Item nesting would make "parent files" use folder icon. For example, if you had appsettings.json and appsettings.development.json in your project, with Item Nesting enabled the appsettings.json would use folder icon.
3. Many files/folders were using the icons from the theme, like "mixed" mode. I had not realized this until now. I think this PR makes it so that "solution-explorer" shows the intended icons.

It looks one line was missing to refresh the tree items after changing/setting their icon.