### PR TITLE
Added support for "PropertyGroup" properties within include/exclude paths

### DIFF
--- a/src/core/Projects/Managers/XmlManager.ts
+++ b/src/core/Projects/Managers/XmlManager.ts
@@ -486,7 +486,10 @@ export class XmlManager implements Manager {
         this._toolsVersion = project.attributes && project.attributes.ToolsVersion;
 
         const properties: Record<string, string> = {};
-        if (this.includePrefix) properties[this.includePrefix] = "";
+        if (this.includePrefix?.startsWith("$(") && this.includePrefix?.endsWith(")")) {
+            const propertyName = this.includePrefix.substring(2, this.includePrefix.length - 1);
+            properties[propertyName] = "";
+        }
 
         project.elements.forEach((element: XmlElement) => {
             if (element.name === 'PropertyGroup') {


### PR DESCRIPTION
Using properties in include/exclude paths results in the project being unloadable (loading animation forever). Here is an example that triggers the error:
```
<PropertyGroup>
	<MpaRoot>ClientApp\</MpaRoot>
</PropertyGroup>
<ItemGroup>
	<!-- Don't publish the MPA source files, but do show them in the project files list -->
	<Content Remove="$(MpaRoot)**" />
	<None Remove="$(MpaRoot)**" />
	<None Include="$(MpaRoot)**" Exclude="$(MpaRoot)node_modules\**" />
</ItemGroup>
```
While the following works as intended:
```
<ItemGroup>
	<!-- Don't publish the MPA source files, but do show them in the project files list -->
	<Content Remove="ClientApp\**" />
	<None Remove="ClientApp\**" />
	<None Include="ClientApp\**" Exclude="ClientApp\node_modules\**" />
</ItemGroup>
```
This PR parses all properties defined in PropertyGroup elements and performs a search and replace. So it adds support for properties like `$(TargetFramework)` but does not add support for properties defined outside the project file, like `$(BaseOutputPath)` and `$(Configuration)`. Issue #102 mentions a problem with these properties. Issue #255 could also be affected by this problem, but there is not enough information about it right now.