### PR TITLE
Fixed bug that prevented pasting files

### DIFF
--- a/src/actions/Paste.ts
+++ b/src/actions/Paste.ts
@@ -19,7 +19,7 @@ export class Paste implements Action {
 
         if (!(await fs.exists(data))) { return; }
 
-        const isDirectory = await fs.isDirectory(this.targetPath);
+        const isDirectory = await fs.isDirectory(data);
         if (isDirectory) {
             this.copyDirectory(data, this.targetPath);
         } else {


### PR DESCRIPTION
There was a small bug preventing copying and pasting a file via the menu (or keybindings if they were fixed).

Pasting folders was not affected.