### PR TITLE
Display files in proj order for F# projects, matches VS

### DIFF
--- a/src/tree/TreeItemFactory.ts
+++ b/src/tree/TreeItemFactory.ts
@@ -111,11 +111,13 @@ export async function createItemsFromProject(context: TreeItemContext, project: 
                 return  x < y ? -1 : x > y ? 1 : 0;
             }
         });
-        files.sort((a, b) => {
-            const x : string = a.name.toLowerCase();
-            const y : string = b.name.toLowerCase();
-            return  x < y ? -1 : x > y ? 1 : 0;
-        });
+        if(!project.fullPath.endsWith('.fsproj')){
+            files.sort((a, b) => {
+                const x : string = a.name.toLowerCase();
+                const y : string = b.name.toLowerCase();
+                return  x < y ? -1 : x > y ? 1 : 0;
+            });
+        } 
     }
 
     folders.forEach(folder => {


### PR DESCRIPTION
## Motivation

Improve the F# experience by matching fsproj file ordering with Visual Studio, since F# file order matters for compilation and dependency.

## Current Behavior

The solution view sorts files alphabetically for all project types

## Behavior after PR

F# files are not sorted in the solution view. They remain in the order they were discovered using the fsproj file. 
This matches Visual Studio. I also verified behavior for project items that match multiple files.
![image](https://user-images.githubusercontent.com/2847259/224198314-6ba30a84-72f2-436d-bf49-33e42335bb13.png)


I think we could probably close #131. F# files are properly added, renamed, and removed from fsproj files. Not as part of this PR, but it must have become supported by some previous work.

## Follow up work

It'd be good to either
- Add move up and move down commands for F# projects 
- OR make it a bit quicker to access the proj file where we can edit the file order

It's also a bit unintuitive that new fs files add to the last item group and not to the item group containing other `Compile` project items. Perhaps we could modify `XmlManager.checkCurrentItemGroup` to prefer a group containing the same kinds of items before defaulting to the last item group?