### PR TITLE
Add option to open a project file on click

### DIFF
--- a/package.json
+++ b/package.json
@@ -767,6 +767,11 @@
                     "default": false,
                     "description": "Sets whether related items will be displayed nested"
                 },
+                "vssolution.openProjectOnClick": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Sets whether clicking a project in the explorer tree opens the underlying proj file (i.e. the csproj or fsproj)"
+              },
                 "vssolution.openSolutions.inRootFolder": {
                     "type": "boolean",
                     "default": true,

--- a/src/extensions/config.ts
+++ b/src/extensions/config.ts
@@ -15,6 +15,7 @@ const XML_CLOSING_TAG_SPACE_NAME = 'xmlClosingTagSpace';
 const WIN32_ENCODING_NAME = 'win32Encoding';
 const LINE_ENDINGS_NAME = 'lineEndings';
 const ITEM_NESTING_NAME = 'itemNesting';
+const OPEN_PROJECT_ON_CLICK = 'openProjectOnClick';
 const OPEN_SOLUTIONS_IN_ROOT_FOLDER_NAME = 'openSolutions.inRootFolder';
 const OPEN_SOLUTIONS_IN_ALTERNATIVE_FOLDERS_NAME = 'openSolutions.inAltFolders';
 const OPEN_SOLUTIONS_IN_FOLDER_AND_SUBFOLDERS_NAME = 'openSolutions.inFoldersAndSubfolders';
@@ -103,6 +104,10 @@ export function getLineEndings() : LineEndingsType {
 
 export function getItemNesting(): boolean {
     return config.get<boolean>(ITEM_NESTING_NAME, false);
+}
+
+export function getOpenProjectOnClick(): boolean {
+    return config.get<boolean>(OPEN_PROJECT_ON_CLICK, false);
 }
 
 export function getOpenSolutionsInRootFolder(): boolean {

--- a/src/tree/items/ProjectTreeItem.ts
+++ b/src/tree/items/ProjectTreeItem.ts
@@ -1,12 +1,21 @@
 import { ProjectInSolution } from "@core/Solutions";
 import { TreeItem, TreeItemCollapsibleState, TreeItemFactory, TreeItemContext, ContextValues } from "@tree";
 import { ProjectReferencesTreeItem } from "./ProjectReferencesTreeItem";
+import { getOpenProjectOnClick } from "@extensions/config"
 
 export class ProjectTreeItem extends TreeItem {
     constructor(context: TreeItemContext, projectInSolution: ProjectInSolution) {
         super(context, projectInSolution.projectName, TreeItemCollapsibleState.Collapsed, ContextValues.project, projectInSolution.fullPath, projectInSolution);
         this.allowIconTheme = false;
         this.addContextValueSuffix();
+
+        if (getOpenProjectOnClick()){
+            this.command = {
+                command: 'solutionExplorer.openFile',
+                arguments: [this],
+                title: 'Open File'
+            };        
+        }
     }
 
     public refresh(): void {
@@ -14,7 +23,7 @@ export class ProjectTreeItem extends TreeItem {
             super.refresh()
         });
 	}
-
+    
     protected async createChildren(childContext: TreeItemContext): Promise<TreeItem[]> {
         let result: TreeItem[] = [];
         if (!this.project) {


### PR DESCRIPTION
## Motivation

I'm aiming to make the F# editing experience smoother with Visual Studio as a reference.
In particular, F# requires files to be in dependency order in the fsproj.

See also #268

## Current Behavior
Changing F# file order requires right clicking a project selecting open file.
Or, a user can switch to the normal file explorer to edit the fsproj file.


## Alternatives
I see three main alternatives to solve this problem
- add move up and move down commands to file items in the explorer
- Add quick access to the fsproj file
  - add a button to project tree item that opens the file 
  - changes project click behavior to open the project file instead of expand/collapse

After exploring, I decided that adding optional click behavior to project tree items was best.
It is a small change, it allows behavior similar to Visual Studio, the feature has already been requested (#179),
and it simplifies other project editing (which has become more common since the new csproj approach).

## Behavior after PR

By default, the behavior will be unchanged. 
The users can set a boolean configuration value that will change the behavior when project items are clicked.
Instead of expanding / collapsing, the project's underlying file will be opened.