### PR TITLE
Add optional inline project edit button

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
             {
                 "command": "solutionExplorer.openFile",
                 "title": "Open File",
-                "category": "Solution Explorer"
+                "category": "Solution Explorer",
+                "icon": "$(edit)"
             },
             {
                 "command": "solutionExplorer.renameFile",
@@ -462,6 +463,11 @@
                 "group": "7_modification"
               },
               {
+                "command": "solutionExplorer.openFile",
+                "when": "config.vssolution.openProjectInlineButtonShown && view in solutionexplorer.viewTypes && viewItem == project-cps",
+                "group": "inline"
+              },
+              {
                 "command": "solutionExplorer.createNewSolution",
                 "when": "view in solutionexplorer.viewTypes && viewItem in solutionExplorer.cmdAllowedContexts.createNewSolution",
                 "group": "2_workspace"
@@ -771,7 +777,12 @@
                   "type": "boolean",
                   "default": false,
                   "description": "Sets whether clicking a project in the explorer tree opens the underlying proj file (i.e. the csproj or fsproj)"
-              },
+                },
+                "vssolution.openProjectInlineButtonShown": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Sets whether projects in the explorer tree include an inline button to open the underlying project file (i.e. the csproj or fsproj)"
+                },
                 "vssolution.openSolutions.inRootFolder": {
                     "type": "boolean",
                     "default": true,

--- a/src/extensions/config.ts
+++ b/src/extensions/config.ts
@@ -16,6 +16,7 @@ const WIN32_ENCODING_NAME = 'win32Encoding';
 const LINE_ENDINGS_NAME = 'lineEndings';
 const ITEM_NESTING_NAME = 'itemNesting';
 const OPEN_PROJECT_ON_CLICK = 'openProjectOnClick';
+const OPEN_PROJECT_INLINE_BUTTON_SHOWN = 'openProjectInlineButtonShown';
 const OPEN_SOLUTIONS_IN_ROOT_FOLDER_NAME = 'openSolutions.inRootFolder';
 const OPEN_SOLUTIONS_IN_ALTERNATIVE_FOLDERS_NAME = 'openSolutions.inAltFolders';
 const OPEN_SOLUTIONS_IN_FOLDER_AND_SUBFOLDERS_NAME = 'openSolutions.inFoldersAndSubfolders';
@@ -108,6 +109,10 @@ export function getItemNesting(): boolean {
 
 export function getOpenProjectOnClick(): boolean {
     return config.get<boolean>(OPEN_PROJECT_ON_CLICK, false);
+}
+
+export function getOpenProjectInlineButtonShown(): boolean {
+    return config.get<boolean>(OPEN_PROJECT_INLINE_BUTTON_SHOWN, true);
 }
 
 export function getOpenSolutionsInRootFolder(): boolean {


### PR DESCRIPTION
## Motivation

A continuation of #269 which opened the project file on click in the explorer like Visual Studio does. The other popular F# editor is Ionide, which instead offers an inline button to edit the project file.  

Supporting similar behavior could ease transition. It's also just a nice balanced option for quick access and a larger expand/collapse target.

## Behavior after PR 
By default there will be an inline button to edit the project file. This can be turned off in the settings.

![image](https://user-images.githubusercontent.com/2847259/224867083-eac06dc0-abe2-48bb-82c4-211f1c3f67a4.png)
![image](https://user-images.githubusercontent.com/2847259/224867848-7cc151df-d2a6-46fa-beb6-66d3a4b3e1aa.png)

## Decisions worth noting

### Config naming
The configuration option is "Open Project Inline Button Shown". This is less direct than "Show Inline Edit Project Button".
But, I chose it because it puts the two open project options right next to each other.

Alternatively, we could make the behaviors one configuration option with an enum.
I chose not to do that since it's plausible someone might want to toggle both. 
Plus, I think [only boolean config settings can be accessed directly from when constraints](https://code.visualstudio.com/api/references/when-clause-contexts)

### Icon

I chose the edit icon for opening the project since it seemed intuitive. But VS Code has [other sensible built-in icons](https://code.visualstudio.com/api/references/icons-in-label) like
- file-code
- go-to-file
- arrow-right