### PR TITLE
Add missing permission to copy-paste f# files

### DIFF
--- a/src/SolutionExplorerCommands.ts
+++ b/src/SolutionExplorerCommands.ts
@@ -45,7 +45,7 @@ export class SolutionExplorerCommands {
             undefined];
 
         this.commands['copy'] = [new cmds.CopyCommand(),
-            [ContextValues.projectFolder, ContextValues.projectFile]];
+            [ContextValues.projectFolder, ContextValues.projectFile, ...fsharp(ContextValues.projectFile)]];
 
         this.commands['createFile'] = [new cmds.CreateFileCommand(templateEngineCollection),
             [ContextValues.projectFile, ContextValues.projectFolder, ...both(ContextValues.project)]];


### PR DESCRIPTION
I noticed file tree items wouldn't copy inside F# projects, but C# projects and folders inside F# projects were fine.

Adding a F# permissions to the copy command fixes this behavior, assuming it was unintended.