### PR TITLE
F# support: Create File above/below

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,18 @@
                 "icon": "$(new-file)"
             },
             {
+                "command": "solutionExplorer.createFileAbove",
+                "title": "Create file above",
+                "category": "Solution Explorer",
+                "icon": "$(new-file)"
+            },
+            {
+              "command": "solutionExplorer.createFileBelow",
+              "title": "Create file below",
+              "category": "Solution Explorer",
+              "icon": "$(new-file)"
+            },
+            {
                 "command": "solutionExplorer.renameFolder",
                 "title": "Rename",
                 "category": "Solution Explorer"
@@ -378,6 +390,16 @@
                 "command": "solutionExplorer.createFile",
                 "when": "view in solutionexplorer.viewTypes && viewItem == project-folder",
                 "group": "inline"
+              },
+              {
+                "command": "solutionExplorer.createFileAbove",
+                "when": "view in solutionexplorer.viewTypes && viewItem in solutionExplorer.cmdAllowedContexts.createFileAbove",
+                "group": "2_workspace"
+              },
+              {
+                "command": "solutionExplorer.createFileBelow",
+                "when": "view in solutionexplorer.viewTypes && viewItem in solutionExplorer.cmdAllowedContexts.createFileBelow",
+                "group": "2_workspace"
               },
               {
                 "command": "solutionExplorer.renameFolder",

--- a/src/SolutionExplorerCommands.ts
+++ b/src/SolutionExplorerCommands.ts
@@ -5,6 +5,7 @@ import { IEventAggregator } from "@events";
 import { TemplateEngineCollection } from "@templates";
 import { ContextValues, TreeItem } from "@tree";
 import { ActionsRunner } from "./ActionsRunner";
+import { Direction } from "@core/Projects/RelativeFilePosition";
 
 export class SolutionExplorerCommands {
     private commands: { [id: string]: [command: cmds.ActionsCommand, allowedContexts: string[] | undefined] } = {};
@@ -49,6 +50,12 @@ export class SolutionExplorerCommands {
 
         this.commands['createFile'] = [new cmds.CreateFileCommand(templateEngineCollection),
             [ContextValues.projectFile, ContextValues.projectFolder, ...both(ContextValues.project)]];
+
+        this.commands['createFileAbove'] = [new cmds.CreateFileCommand(templateEngineCollection, Direction.Above),
+            [...fsharp(ContextValues.projectFile)]];
+
+        this.commands['createFileBelow'] = [new cmds.CreateFileCommand(templateEngineCollection, Direction.Below),
+            [...fsharp(ContextValues.projectFile)]];
 
         this.commands['createFolder'] = [new cmds.CreateFolderCommand(),
             [ContextValues.projectFile, ContextValues.projectFolder, ...both(ContextValues.project)]];

--- a/src/actions/CreateProjectFile.ts
+++ b/src/actions/CreateProjectFile.ts
@@ -1,8 +1,10 @@
 import { Project } from "@core/Projects";
 import { Action, ActionContext } from "./base/Action";
+import { RelativeFilePosition } from "@core/Projects/RelativeFilePosition";
 
 export class CreateProjectFile implements Action {
-    constructor(private readonly project: Project, private readonly folderPath: string, private readonly filename: string, private readonly content?: string) {
+    constructor(private readonly project: Project, private readonly folderPath: string, private readonly filename: string, 
+        private readonly content?: string, private readonly relativePosition?:RelativeFilePosition) {
     }
 
     public async execute(context: ActionContext): Promise<void> {
@@ -10,7 +12,7 @@ export class CreateProjectFile implements Action {
             return;
         }
 
-        await this.project.createFile(this.folderPath, this.filename, this.content);
+        await this.project.createFile(this.folderPath, this.filename, this.content, this.relativePosition);
     }
 
     public toString(): string {

--- a/src/commands/CreateFileCommand.ts
+++ b/src/commands/CreateFileCommand.ts
@@ -4,13 +4,14 @@ import { TreeItem, ContextValues } from "@tree";
 import { Action, CreateProjectFile, OpenFile } from "@actions";
 import { SingleItemActionsCommand } from "@commands";
 import { TemplateEngineCollection } from "@templates";
+import { Direction, RelativeFilePosition } from "@core/Projects/RelativeFilePosition";
 
 export class CreateFileCommand extends SingleItemActionsCommand {
     private workspaceRoot: string = '';
     private defaultExtension: string = '';
     private wizard: dialogs.Wizard | undefined;
 
-    constructor(private readonly templaceEngineCollection: TemplateEngineCollection) {
+    constructor(private readonly templaceEngineCollection: TemplateEngineCollection, private readonly relativeToSelected?: Direction) {
         super('Create file');
     }
 
@@ -23,8 +24,13 @@ export class CreateFileCommand extends SingleItemActionsCommand {
 
         this.workspaceRoot = item.workspaceRoot;
         this.defaultExtension = item.project.fileExtension;
-
-
+        const relativeTo : RelativeFilePosition | undefined = 
+            !this.relativeToSelected ? 
+            undefined : 
+            { 
+                fullpath: item.path,
+                direction: this.relativeToSelected
+            };
 
         this.wizard = dialogs.wizard(this.title)
                              .getText('New file name', 'file.extension')
@@ -36,7 +42,7 @@ export class CreateFileCommand extends SingleItemActionsCommand {
                 const folderpath = this.getFolderPath(item);
                 const filename = this.getFilename(this.wizard.context.results[0]);
                 return [
-                    new CreateProjectFile(item.project, folderpath, filename),
+                    new CreateProjectFile(item.project, folderpath, filename, undefined, relativeTo),
                     new OpenFile(path.join(folderpath, filename))
                 ];
             }
@@ -49,7 +55,7 @@ export class CreateFileCommand extends SingleItemActionsCommand {
         const filepath = path.join(folderpath, filename);
 
         return [
-            new CreateProjectFile(item.project, folderpath, filename, content),
+            new CreateProjectFile(item.project, folderpath, filename, content, relativeTo),
             new OpenFile(filepath)
         ];
     }

--- a/src/core/Projects/Managers/FileManager.ts
+++ b/src/core/Projects/Managers/FileManager.ts
@@ -1,6 +1,7 @@
 import * as path from "@extensions/path";
 import * as fs from "@extensions/fs";
 import { ProjectFileStat } from "../ProjectFileStat";
+import { RelativeFilePosition } from "../RelativeFilePosition";
 
 export class FileManager {
     private readonly projectFolderPath: string;
@@ -19,7 +20,7 @@ export class FileManager {
         }
     }
 
-    public async createFile(folderpath: string, filename: string, content?: string): Promise<string> {
+    public async createFile(folderpath: string, filename: string, content?: string, relativePosition?:RelativeFilePosition): Promise<string> {
         let filepath = path.join(folderpath, filename);
         if (!(await fs.exists(filepath))) {
             await fs.writeFile(filepath, content || "");

--- a/src/core/Projects/Managers/Manager.ts
+++ b/src/core/Projects/Managers/Manager.ts
@@ -1,8 +1,8 @@
 import { ProjectFileStat } from "../ProjectFileStat";
-
+import { RelativeFilePosition } from "../RelativeFilePosition"; "../RelativeFilePosition";
 
 export interface Manager {
-    createFile(folderpath: string, filename: string, content?: string): Promise<string>;
+    createFile(folderpath: string, filename: string, content?: string, relativePosition?:RelativeFilePosition): Promise<string>;
     createFolder(folderpath: string): Promise<string>;
     deleteFile(filepath: string): Promise<void>;
     deleteFolder(folderpath: string): Promise<void>;

--- a/src/core/Projects/Managers/XmlManager.ts
+++ b/src/core/Projects/Managers/XmlManager.ts
@@ -146,31 +146,18 @@ export class XmlManager implements Manager {
         const project = XmlManager.getProjectElement(this.document);
         if (!project) { return filepath; }
 
-        for(let i = 0; i < project.elements.length; i++) {
-            const element = project.elements[i];
-            if (element.name === 'ItemGroup') {
-                if (!element.elements || !Array.isArray(element.elements)) {
-                    element.elements = [];
+        this.someProjectItem(project, (itemGroup, e) =>{
+            if (e.attributes && e.attributes.Include && e.attributes.Include.toLocaleLowerCase() === relativePath.toLocaleLowerCase()) {
+                const index = itemGroup.elements.indexOf(e);
+                if (index > 0) {
+                    itemGroup.elements.splice(index, 1);
+                    itemGroup.elements.splice(index - 1, 0, e);
                 }
 
-                const b = element.elements.some((e: xml.XmlElement) => {
-                    if (nodeNames.length === 0 || nodeNames.indexOf(e.name) > -1) {
-                        if (e.attributes && e.attributes.Include && e.attributes.Include.toLocaleLowerCase() === relativePath.toLocaleLowerCase()) {
-                            const index = element.elements.indexOf(e);
-                            if (index > 0) {
-                                element.elements.splice(index, 1);
-                                element.elements.splice(index - 1, 0, e);
-                            }
-
-                            return true;
-                        }
-                    }
-                });
-                if (b) {
-                    break;
-                }
+                return true;
             }
-        }
+            return false;
+        });
 
         await this.saveProject();
         return filepath;
@@ -185,31 +172,18 @@ export class XmlManager implements Manager {
         const project = XmlManager.getProjectElement(this.document);
         if (!project) { return filepath; }
 
-        for(let i = 0; i < project.elements.length; i++) {
-            const element = project.elements[i];
-            if (element.name === 'ItemGroup') {
-                if (!element.elements || !Array.isArray(element.elements)) {
-                    element.elements = [];
+        this.someProjectItem(project, (itemGroup, e) =>{
+            if (e.attributes && e.attributes.Include && e.attributes.Include.toLocaleLowerCase() === relativePath.toLocaleLowerCase()) {
+                const index = itemGroup.elements.indexOf(e);
+                if (index > -1 && index < itemGroup.elements.length - 1) {
+                    itemGroup.elements.splice(index, 1);
+                    itemGroup.elements.splice(index + 1, 0, e);
                 }
 
-                const b = element.elements.some((e: xml.XmlElement) => {
-                    if (nodeNames.length === 0 || nodeNames.indexOf(e.name) > -1) {
-                        if (e.attributes && e.attributes.Include && e.attributes.Include.toLocaleLowerCase() === relativePath.toLocaleLowerCase()) {
-                            const index = element.elements.indexOf(e);
-                            if (index > -1 && index < element.elements.length - 1) {
-                                element.elements.splice(index, 1);
-                                element.elements.splice(index + 1, 0, e);
-                            }
-
-                            return true;
-                        }
-                    }
-                });
-                if (b) {
-                    break;
-                }
+                return true;
             }
-        }
+            return false;
+        });
 
         await this.saveProject();
         return filepath;

--- a/src/core/Projects/Managers/XmlManager.ts
+++ b/src/core/Projects/Managers/XmlManager.ts
@@ -6,6 +6,7 @@ import * as config from "@extensions/config";
 import { Include, ProjectItem, ProjectItemsFactory } from "../Items";
 import { ProjectFileStat } from "../ProjectFileStat";
 import { Manager } from "./Manager";
+import { Direction, RelativeFilePosition } from "../RelativeFilePosition";
 
 export class XmlManager implements Manager {
     private readonly projectFolderPath: string;
@@ -35,7 +36,7 @@ export class XmlManager implements Manager {
         return this.fullPath.toLocaleLowerCase().endsWith(".fsproj");
     }
 
-    public async createFile(folderpath: string, filename: string, content?: string): Promise<string> {
+    public async createFile(folderpath: string, filename: string, content?: string, relativePosition?: RelativeFilePosition): Promise<string> {
         await this.ensureIsLoaded();
 
         const folderRelativePath = this.getRelativePath(folderpath);
@@ -60,7 +61,7 @@ export class XmlManager implements Manager {
 
         const fullPath = path.join(this.projectFolderPath, relativePath);
         if (!this.isCurrentlyIncluded(fullPath)) {
-            this.currentItemGroupAdd(type, relativePath);
+            this.currentItemGroupAdd(type, relativePath, undefined, relativePosition);
         }
 
         await this.saveProject();
@@ -487,7 +488,24 @@ export class XmlManager implements Manager {
         }
     }
 
-    private currentItemGroupAdd(type: string, include: string, isFolder: boolean = false): void {
+    private someProjectItem(project: xml.XmlElement, test:(group:xml.XmlElement, item:xml.XmlElement) => Boolean): xml.XmlElement | undefined {
+        const nodeNames = this.getXmlNodeNames();
+        const isValidElement = (e: xml.XmlElement) => nodeNames.length === 0 || nodeNames.indexOf(e.name) > -1;
+
+        for(let i = 0; i < project.elements.length; i++) {
+            const maybeGroup = project.elements[i];
+            if(maybeGroup.name === 'ItemGroup' && maybeGroup.elements && Array.isArray(maybeGroup.elements)){
+                const curried = (item: xml.XmlElement) : Boolean => isValidElement(item) ? test(maybeGroup, item) : false
+                
+                const item = maybeGroup.elements.some(curried);
+                if(item){
+                    return item;
+                }
+            }
+       }
+    }
+
+    private currentItemGroupAdd(type: string, include: string, isFolder: boolean = false, relativePosition?: RelativeFilePosition): void {
         const itemGroup = this.checkCurrentItemGroup();
         if (!itemGroup) { return; }
 
@@ -501,13 +519,39 @@ export class XmlManager implements Manager {
             return;
         }
 
-        itemGroup.elements.push({
+        const newItemElement = {
             type: 'element',
             name: type,
             attributes: {
                 ["Include"]: include
             }
-        });
+        }
+
+        if(relativePosition){
+            if(!this.document) return;
+            const project = XmlManager.getProjectElement(this.document);
+            if(!project){return;}
+            
+            const lowercaseTargetFilePath = this.getRelativePath(relativePosition.fullpath).toLocaleLowerCase();
+            
+            this.someProjectItem(project, (itemGroup, e) =>{
+                if (e.attributes && e.attributes.Include && e.attributes.Include.toLocaleLowerCase() === lowercaseTargetFilePath) {
+
+                    const index = itemGroup.elements.indexOf(e);
+                    if (index > 0) {
+                        const indexOffset = relativePosition.direction === Direction.Above ? 0 : 1;
+                        itemGroup.elements.splice(index + indexOffset, 0, newItemElement);
+                    }
+
+                    return true;
+                }
+
+                return false;
+            });
+        }
+        else{
+            itemGroup.elements.push(newItemElement);
+        }
     }
 
     private checkCurrentItemGroup(): XmlElement | undefined {

--- a/src/core/Projects/Project.ts
+++ b/src/core/Projects/Project.ts
@@ -2,6 +2,7 @@ import * as path from "@extensions/path";
 import { NugetDependencies } from "@extensions/nuget-dependencies";
 import { PackageReference, ProjectItemEntry, ProjectReference, Reference } from "./Items";
 import { ProjectFileStat } from "./ProjectFileStat";
+import { RelativeFilePosition } from "./RelativeFilePosition";
 
 export abstract class Project {
     constructor(public readonly projectFullPath: string, private readonly withReferences?: boolean) {
@@ -43,7 +44,7 @@ export abstract class Project {
 
     public abstract deleteFile(filepath: string): Promise<void>;
 
-    public abstract createFile(folderpath: string, filename: string, content?: string): Promise<string>;
+    public abstract createFile(folderpath: string, filename: string, content?: string, relativePosition?:RelativeFilePosition): Promise<string>;
 
     public abstract renameFolder(folderpath: string, oldname: string, newname: string): Promise<string>;
 

--- a/src/core/Projects/ProjectWithManagers.ts
+++ b/src/core/Projects/ProjectWithManagers.ts
@@ -1,6 +1,7 @@
 import { ProjectFileStat } from "./ProjectFileStat";
 import { ProjectWithNugetDependencies } from "./ProjectWithNugetDependencies";
 import { Manager, XmlManager, FileManager } from "./Managers";
+import { RelativeFilePosition } from "./RelativeFilePosition";
 
 export abstract class ProjectWithManagers extends ProjectWithNugetDependencies {
     protected readonly xml: XmlManager;
@@ -25,8 +26,8 @@ export abstract class ProjectWithManagers extends ProjectWithNugetDependencies {
         await this.xml.refresh();
     }
 
-    public createFile(folderpath: string, filename: string, content?: string | undefined): Promise<string> {
-        return this.callInManagers(m => m.createFile(folderpath, filename, content));
+    public createFile(folderpath: string, filename: string, content?: string | undefined, relativePosition?:RelativeFilePosition): Promise<string> {
+        return this.callInManagers(m => m.createFile(folderpath, filename, content, relativePosition));
     }
 
     public createFolder(folderpath: string): Promise<string> {

--- a/src/core/Projects/RelativeFilePosition.ts
+++ b/src/core/Projects/RelativeFilePosition.ts
@@ -1,0 +1,7 @@
+
+export enum Direction {
+    Above = "above",
+    Below = "below"
+}
+
+export type RelativeFilePosition = { fullpath: string; direction: Direction};


### PR DESCRIPTION
## Motivation
See issue #270 

## Behavior Before PR

Creating a project file item for F# projects adds it to the end of the item list and displayed files.
It can then be moved using move up or directly editing the project file.

## Behavior After PR

![add-below-2](https://user-images.githubusercontent.com/2847259/226082623-82238272-c52c-4226-b27f-c758d962eb16.gif)

Two new context menu items are added for `Create file above` and `Create file below`, but only in F# projects. These actions respect the normal create file experience (i.e. naming, templates) but will insert the created file into the project file next to whatever project item was selected to trigger the command.

This required a new optional parameter passed through the `createFile` call chain.

## Decisions of Note

- I decided to modify and reuse the create file command and it's call chain since there seemed to non-trivial logic that would be duplicated in new commands and easy to forget to maintain. There also didn't seem to be any benefit in splitting out new manager methods or actions. The file manager would have to ignore relative position in any case just like it does with move up/down.
- I named the context menu items with create instead of add (i.e. `Create file above` instead of `Add file above`) This is different from visual studio's naming but consistent with this explorer's naming. We also don't support adding existing items relatively.
- I added the custom type `RelativeFilePosition` to the project folder mimicking how `ProjectFileStat` is handled
- I noticed a decent amount of shared defensive programming and iteration between the move and relative create actions, so I centralized them in `someProjectItem`