### PR TITLE
Display folders in project file order in F# projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,7 +393,7 @@
               },
               {
                 "command": "solutionExplorer.createFile",
-                "when": "view in solutionexplorer.viewTypes && viewItem == project-folder",
+                "when": "view in solutionexplorer.viewTypes && (viewItem == project-folder || viewItem == project-folder-fs)",
                 "group": "inline"
               },
               {
@@ -433,7 +433,7 @@
               },
               {
                 "command": "solutionExplorer.createFolder",
-                "when": "view in solutionexplorer.viewTypes && viewItem == project-folder",
+                "when": "view in solutionexplorer.viewTypes && (viewItem == project-folder || viewItem == project-folder-fs)",
                 "group": "inline"
               },
               {

--- a/src/SolutionExplorerCommands.ts
+++ b/src/SolutionExplorerCommands.ts
@@ -16,7 +16,7 @@ export class SolutionExplorerCommands {
                 private readonly templateEngineCollection: TemplateEngineCollection,
                 private readonly eventAggregator: IEventAggregator) {
 
-        const { cps, both, fsharp } = ContextValues;
+        const { cps, both, fsharp, anyLang } = ContextValues;
 
         this.commands['addExistingProject'] = [new cmds.AddExistingProjectCommand(provider),
             both(ContextValues.solution)];
@@ -46,10 +46,10 @@ export class SolutionExplorerCommands {
             undefined];
 
         this.commands['copy'] = [new cmds.CopyCommand(),
-            [ContextValues.projectFolder, ContextValues.projectFile, ...fsharp(ContextValues.projectFile)]];
+            anyLang(ContextValues.projectFolder, ContextValues.projectFile)];
 
         this.commands['createFile'] = [new cmds.CreateFileCommand(templateEngineCollection),
-            [ContextValues.projectFile, ContextValues.projectFolder, ...both(ContextValues.project)]];
+            [ContextValues.projectFile, ...anyLang(ContextValues.projectFolder), ...both(ContextValues.project)]];
 
         this.commands['createFileAbove'] = [new cmds.CreateFileCommand(templateEngineCollection, Direction.Above),
             [...fsharp(ContextValues.projectFile)]];
@@ -58,7 +58,7 @@ export class SolutionExplorerCommands {
             [...fsharp(ContextValues.projectFile)]];
 
         this.commands['createFolder'] = [new cmds.CreateFolderCommand(),
-            [ContextValues.projectFile, ContextValues.projectFolder, ...both(ContextValues.project)]];
+            [ContextValues.projectFile, ...anyLang(ContextValues.projectFolder), ...both(ContextValues.project)]];
 
         this.commands['createNewSolution'] = [new cmds.CreateNewSolutionCommand(),
             [ContextValues.noSolution]];
@@ -70,7 +70,7 @@ export class SolutionExplorerCommands {
             [ContextValues.projectFile, ...fsharp(ContextValues.projectFile)]];
 
         this.commands['deleteFolder'] = [new cmds.DeleteUnifiedCommand(),
-            [ContextValues.projectFolder]];
+            anyLang(ContextValues.projectFolder)];
 
         this.commands['deleteSolutionFile'] = [new cmds.DeleteUnifiedCommand(),
             [ContextValues.solutionFile]];
@@ -88,13 +88,13 @@ export class SolutionExplorerCommands {
             [ContextValues.projectFile, ...fsharp(ContextValues.projectFile)]];
 
         this.commands['moveFileUp'] = [new cmds.MoveFileUpCommand(provider),
-            [...fsharp(ContextValues.projectFile)]];
+            fsharp(ContextValues.projectFile, ContextValues.projectFolder)];
 
         this.commands['moveFileDown'] = [new cmds.MoveFileDownCommand(provider),
-            [...fsharp(ContextValues.projectFile)]];
+            fsharp(ContextValues.projectFile, ContextValues.projectFolder)];
 
         this.commands['moveFolder'] = [new cmds.MoveCommand(provider),
-            [ContextValues.projectFolder]];
+            anyLang(ContextValues.projectFolder)];
 
         this.commands['moveToSolutionFolder'] = [new cmds.MoveToSolutionFolderCommand(),
             [ContextValues.solutionFolder, ...both(ContextValues.project)]];
@@ -106,13 +106,13 @@ export class SolutionExplorerCommands {
             cps(ContextValues.solution, ContextValues.project)];
 
         this.commands['paste'] = [new cmds.PasteCommand(provider),
-            [ContextValues.projectFolder, ContextValues.projectFile, ...fsharp(ContextValues.projectFile), ...both(ContextValues.project)]];
+            [...anyLang(ContextValues.projectFolder, ContextValues.projectFile), ...both(ContextValues.project)]];
 
         this.commands['publish'] = [new cmds.PublishCommand(),
             cps(ContextValues.solution, ContextValues.project)];
 
         this.commands['refresh'] = [new cmds.RefreshCommand(provider),
-            [ContextValues.projectFolder, ContextValues.solutionFolder, ...both(ContextValues.project)]];
+            [...anyLang(ContextValues.projectFolder), ContextValues.solutionFolder, ...both(ContextValues.project)]];
 
         this.commands['removePackage'] = [new cmds.DeleteUnifiedCommand(),
             cps(ContextValues.projectReferencedPackage)];
@@ -130,7 +130,7 @@ export class SolutionExplorerCommands {
             [ContextValues.projectFile, ...fsharp(ContextValues.projectFile)]];
 
         this.commands['renameFolder'] = [new cmds.RenameCommand(),
-            [ContextValues.projectFolder]];
+            anyLang(ContextValues.projectFolder)];
 
         this.commands['renameSolutionItem'] = [new cmds.RenameSolutionItemCommand(provider),
             [ContextValues.solutionFolder, ...both(ContextValues.solution, ContextValues.project)]];

--- a/src/commands/DeleteUnifiedCommand.ts
+++ b/src/commands/DeleteUnifiedCommand.ts
@@ -30,9 +30,9 @@ export class DeleteUnifiedCommand extends ActionsCommand {
         }
         else if (topClickedItems.length > 1) {
 
-            const { both, cps, fsharp } = ContextValues;
+            const { both, cps, anyLang } = ContextValues;
             const allowedContextGroups = [
-                [ContextValues.projectFile, ...fsharp(ContextValues.projectFile), ContextValues.projectFolder],
+                anyLang(ContextValues.projectFile, ContextValues.projectFolder),
                 cps(ContextValues.projectReferencedPackage, ContextValues.projectReferencedProject),
                 both(ContextValues.project),
                 [ContextValues.solutionFile, ContextValues.solutionFolder],
@@ -102,6 +102,9 @@ export class DeleteUnifiedCommand extends ActionsCommand {
                 ? [new DeleteProjectFile(item.project, item.path, showDialog)] : []],
 
             [ContextValues.projectFolder, item => item.project && item.path
+                ? [new DeleteProjectFolder(item.project, item.path, showDialog)] : []],
+
+            [ContextValues.projectFolder, 'fs', item => item.project && item.path
                 ? [new DeleteProjectFolder(item.project, item.path, showDialog)] : []],
 
             [ContextValues.projectReferencedPackage, 'cps', item => item.project && item.path

--- a/src/commands/MoveFileDownCommand.ts
+++ b/src/commands/MoveFileDownCommand.ts
@@ -10,7 +10,8 @@ export class MoveFileDownCommand extends SingleItemActionsCommand {
     }
 
     public shouldRun(item: TreeItem | undefined): boolean {
-        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path && item.contextValue.startsWith(ContextValues.projectFile);
+        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path 
+        && (item.contextValue.startsWith(ContextValues.projectFile) || item.contextValue.startsWith(ContextValues.projectFolder));
     }
 
     public async getActions(item: TreeItem | undefined): Promise<Action[]> {

--- a/src/commands/MoveFileUpCommand.ts
+++ b/src/commands/MoveFileUpCommand.ts
@@ -10,7 +10,8 @@ export class MoveFileUpCommand extends SingleItemActionsCommand {
     }
 
     public shouldRun(item: TreeItem | undefined): boolean {
-        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path && item.contextValue.startsWith(ContextValues.projectFile);
+        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path 
+        && (item.contextValue.startsWith(ContextValues.projectFile) || item.contextValue.startsWith(ContextValues.projectFolder));
     }
 
     public async getActions(item: TreeItem | undefined): Promise<Action[]> {

--- a/src/tree/ContextValues.ts
+++ b/src/tree/ContextValues.ts
@@ -21,6 +21,9 @@ export class ContextValues {
     public static fsharp(...contexts: FSharpContextValue[]) {
         return contexts.map(ctx => ctx + '-fs');
     }
+    public static anyLang(...contexts: FSharpContextValue[]) {
+        return contexts.map(ctx => ctx + '-fs').concat(contexts);
+    }
     public static both(...contexts: SuffixedContextValue[]) {
         return contexts.flatMap(ctx => [ctx !== ContextValues.solution ? ctx + '-standard' : ctx, ctx + '-cps']);
     }
@@ -36,5 +39,5 @@ type SuffixedContextValue =
 
 type FSharpContextValue =
     //typeof ContextValues.project |
-    //typeof ContextValues.projectFolder |
+    typeof ContextValues.projectFolder |
     typeof ContextValues.projectFile;

--- a/src/tree/items/ProjectFolderTreeItem.ts
+++ b/src/tree/items/ProjectFolderTreeItem.ts
@@ -12,6 +12,7 @@ export class ProjectFolderTreeItem extends TreeItem {
             this.description = "link";
             this.subscription = context.eventAggregator.subscribe(EventTypes.file, evt => this.onFileEvent(evt));
         }
+        this.addContextValueSuffix();
     }
 
     public dispose(): void {
@@ -50,4 +51,10 @@ export class ProjectFolderTreeItem extends TreeItem {
             }
         }
     }
+
+    protected addContextValueSuffix(): void {
+        if (this.project?.extension.toLocaleLowerCase() === 'fsproj') {
+		    this.contextValue += '-fs';
+        }
+	}
 }


### PR DESCRIPTION
#282 

## What happens if the PR is merged
Folders in all kinds of projects always show at the top, but F# folders should be shown in compile order.
This PR updates F# projects to display folders in project file (compile) order.

For example, for this project item group
```xml
<ItemGroup>
    <Compile Include="DefaultValidators.fs" />
    <Compile Include="SpecModule.fs" />
    <Compile Include="Nya/Normalization.fs" />
    <Compile Include="Nya/SpecData.fs" />
    <Compile Include="Formatters.fs" />
    <Compile Include="suchFolder\boi.fs" />
    <Compile Include="suchFolder\Formatters.fs" />
</ItemGroup>
```

The current project item tree before this PR will look like
![image](https://user-images.githubusercontent.com/2847259/235551008-204c5993-acba-455e-97ff-19847f39d30f.png)

After this PR it'll look like
![image](https://user-images.githubusercontent.com/2847259/235551121-1fdd14de-1ebc-4c26-879f-8216216f41a4.png)

## Follow up issues

This PR does not add functionality to move folders up/down via the project explorer UI.

I also noticed that drag-drop is not working for F# projects. The issue predates this PR, thus I think it's a distinct unit of work for a different PR.