### PR TITLE
Enable drag-drop for F# projects

### DIFF
--- a/src/commands/CreateFileCommand.ts
+++ b/src/commands/CreateFileCommand.ts
@@ -62,7 +62,7 @@ export class CreateFileCommand extends SingleItemActionsCommand {
 
     private getFolderPath(item: TreeItem) {
         let targetpath: string = item.path || "";
-        if (!item.contextValue.startsWith(ContextValues.projectFolder)) {
+        if (!ContextValues.matchAnyLanguage(ContextValues.projectFolder, item.contextValue)) {
             targetpath = path.dirname(targetpath);
         }
         return targetpath;

--- a/src/commands/CreateFolderCommand.ts
+++ b/src/commands/CreateFolderCommand.ts
@@ -22,7 +22,7 @@ export class CreateFolderCommand extends SingleItemActionsCommand {
         }
 
         let targetpath: string = item.path;
-        if (!item.contextValue.startsWith(ContextValues.projectFolder)) {
+        if (!ContextValues.matchAnyLanguage(ContextValues.projectFolder, item.contextValue)) {
             targetpath = path.dirname(targetpath);
         }
 

--- a/src/commands/DuplicateCommand.ts
+++ b/src/commands/DuplicateCommand.ts
@@ -11,7 +11,7 @@ export class DuplicateCommand extends SingleItemActionsCommand {
     }
 
     public shouldRun(item: TreeItem | undefined): boolean {
-       return !!item && !!item.path && item.contextValue.startsWith(ContextValues.projectFile);
+       return !!item && !!item.path && ContextValues.matchAnyLanguage(ContextValues.projectFile, item.contextValue);
     }
 
     public async getActions(item: TreeItem | undefined): Promise<Action[]> {

--- a/src/commands/MoveCommand.ts
+++ b/src/commands/MoveCommand.ts
@@ -10,7 +10,9 @@ export class MoveCommand extends SingleItemActionsCommand {
     }
 
     public shouldRun(item: TreeItem | undefined): boolean {
-       return !!item && !!item.project && !!item.path && ( item.contextValue.startsWith(ContextValues.projectFile) || item.contextValue.startsWith(ContextValues.projectFolder) );
+        return !!item && !!item.project && !!item.path
+            && (ContextValues.matchAnyLanguage(ContextValues.projectFile, item.contextValue)
+                || ContextValues.matchAnyLanguage(ContextValues.projectFolder, item.contextValue));
     }
 
     public async getActions(item: TreeItem | undefined): Promise<Action[]> {
@@ -20,10 +22,10 @@ export class MoveCommand extends SingleItemActionsCommand {
         const folder = await dialogs.selectOption('Select folder...', folders);
         if (!folder) { return []; }
 
-        if (item.contextValue.startsWith(ContextValues.projectFile)) {
-            return [ new MoveProjectFile(item.project, item.path, folder) ];
-        } else if (item.contextValue.startsWith(ContextValues.projectFolder)) {
-            return [ new MoveProjectFolder(item.project, item.path, folder) ];
+        if (ContextValues.matchAnyLanguage(ContextValues.projectFile, item.contextValue)) {
+            return [new MoveProjectFile(item.project, item.path, folder)];
+        } else if (ContextValues.matchAnyLanguage(ContextValues.projectFolder, item.contextValue)) {
+            return [new MoveProjectFolder(item.project, item.path, folder)];
         } else {
             return [];
         }

--- a/src/commands/MoveFileDownCommand.ts
+++ b/src/commands/MoveFileDownCommand.ts
@@ -10,7 +10,7 @@ export class MoveFileDownCommand extends SingleItemActionsCommand {
     }
 
     public shouldRun(item: TreeItem | undefined): boolean {
-        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path && item.contextValue.startsWith(ContextValues.projectFile);
+        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path && ContextValues.matchAnyLanguage(ContextValues.projectFile, item.contextValue);
     }
 
     public async getActions(item: TreeItem | undefined): Promise<Action[]> {

--- a/src/commands/MoveFileUpCommand.ts
+++ b/src/commands/MoveFileUpCommand.ts
@@ -10,7 +10,7 @@ export class MoveFileUpCommand extends SingleItemActionsCommand {
     }
 
     public shouldRun(item: TreeItem | undefined): boolean {
-        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path && item.contextValue.startsWith(ContextValues.projectFile);
+        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path && ContextValues.matchAnyLanguage(ContextValues.projectFile, item.contextValue);
     }
 
     public async getActions(item: TreeItem | undefined): Promise<Action[]> {

--- a/src/commands/MoveToSolutionFolderCommand.ts
+++ b/src/commands/MoveToSolutionFolderCommand.ts
@@ -23,11 +23,11 @@ export class MoveToSolutionFolderCommand extends SingleItemActionsCommand {
         const projectInSolution = item.projectInSolution;
         if (!projectInSolution) { return []; }
 
-        if (item.contextValue.startsWith(ContextValues.project)) {
+        if (ContextValues.matchAnyLanguage(ContextValues.project, item.contextValue)) {
             return [ new MoveProject(item.solution, projectInSolution, folder) ];
         }
 
-        if (item.contextValue.startsWith(ContextValues.solutionFolder)) {
+        if (ContextValues.matchAnyLanguage(ContextValues.solutionFolder, item.contextValue)) {
             return [ new MoveSolutionFolder(item.solution, projectInSolution, folder) ];
         }
 

--- a/src/commands/RenameCommand.ts
+++ b/src/commands/RenameCommand.ts
@@ -19,10 +19,10 @@ export class RenameCommand extends SingleItemActionsCommand {
         const newname = await dialogs.getText('New name', 'New name', item.label);
         if (!newname) { return []; }
 
-        if (item.contextValue.startsWith(ContextValues.projectFile)) {
+        if (ContextValues.matchAnyLanguage(ContextValues.projectFile, item.contextValue)) {
             return [ new RenameProjectFile(item.project, item.path, newname) ];
 
-        } else if (item.contextValue.startsWith(ContextValues.projectFolder)) {
+        } else if (ContextValues.matchAnyLanguage(ContextValues.projectFolder, item.contextValue)) {
             return [ new RenameProjectFolder(item.project, item.path, oldname, newname) ];
         }
 

--- a/src/commands/RevealInOSCommand.ts
+++ b/src/commands/RevealInOSCommand.ts
@@ -8,7 +8,7 @@ export class RevealInOSCommand extends SingleItemActionsCommand {
     }
 
     public shouldRun(item: TreeItem | undefined): boolean {
-        return !!item && item.contextValue.startsWith(ContextValues.projectFile);
+        return !!item && ContextValues.matchAnyLanguage(ContextValues.projectFile, item.contextValue);
     }
 
     public async getActions(item: TreeItem | undefined): Promise<Action[]> {

--- a/src/templates/TemplateEngine.ts
+++ b/src/templates/TemplateEngine.ts
@@ -65,7 +65,7 @@ export abstract class TemplateEngine {
         const xmlContent =  await xml.parseToJson(content);
         const projectXml = XmlManager.getProjectElement(xmlContent) || { elements: [] };
         if (parametersGetter) {
-            let result = parametersGetter(filename, item.project.fullPath, item.contextValue.startsWith(ContextValues.projectFolder) ? item.path : undefined, projectXml);
+            let result = parametersGetter(filename, item.project.fullPath, ContextValues.matchAnyLanguage(ContextValues.projectFolder, item.contextValue) ? item.path : undefined, projectXml);
             if (Promise.resolve(result) === result) {
                 result = await (<Promise<any>>result);
             }

--- a/src/tree/ContextValues.ts
+++ b/src/tree/ContextValues.ts
@@ -24,6 +24,10 @@ export class ContextValues {
     public static both(...contexts: SuffixedContextValue[]) {
         return contexts.flatMap(ctx => [ctx !== ContextValues.solution ? ctx + '-standard' : ctx, ctx + '-cps']);
     }
+
+    public static matchAnyLanguage(desiredValue:string, testedValue: string){
+        return testedValue.startsWith(desiredValue);
+    } 
 }
 
 type SuffixedContextValue =

--- a/src/tree/TreeItemIconProvider.ts
+++ b/src/tree/TreeItemIconProvider.ts
@@ -37,23 +37,23 @@ export async function findIconPath(name: string, path: string, contextValue: str
         return getIconPath('sln.svg');
     }
 
-    if (contextValue.startsWith(ContextValues.projectFile)) {
+    if (ContextValues.matchAnyLanguage(ContextValues.projectFile, contextValue)) {
         return await getIconPathFromExtension(path, 'file.svg');
     }
 
-    if (contextValue.startsWith(ContextValues.projectReferences)) {
+    if (ContextValues.matchAnyLanguage(ContextValues.projectReferences, contextValue)) {
         return getIconPath('ReferenceGroup.svg','ReferenceGroup-dark.svg');
     }
 
-    if (contextValue.startsWith(ContextValues.projectReferencedProject)) {
+    if (ContextValues.matchAnyLanguage(ContextValues.projectReferencedProject, contextValue)) {
         return getIconPath('Application.svg','Application-dark.svg');
     }
 
-    if (contextValue.startsWith(ContextValues.projectReferencedPackage)) {
+    if (ContextValues.matchAnyLanguage(ContextValues.projectReferencedPackage, contextValue)) {
         return getIconPath('PackageReference.svg','PackageReference-dark.svg');
     }
 
-    if (contextValue === ContextValues.solutionFolder || contextValue.startsWith(ContextValues.projectFolder)) {
+    if (contextValue === ContextValues.solutionFolder || ContextValues.matchAnyLanguage(ContextValues.projectFolder, contextValue)) {
         if (path && path.endsWith("wwwroot")) {
             return getIconPath('WebFolderOpened.svg','WebFolderOpened-dark.svg');
         }
@@ -69,7 +69,7 @@ export async function findIconPath(name: string, path: string, contextValue: str
         return getIconPath('folder.svg');
     }
 
-    if (contextValue.startsWith(ContextValues.project)) {
+    if (ContextValues.matchAnyLanguage(ContextValues.project, contextValue)) {
         return await getIconPathFromExtension(path, 'csproj.svg');
     }
 

--- a/src/tree/drop/CopyExternalFileInProjects.ts
+++ b/src/tree/drop/CopyExternalFileInProjects.ts
@@ -4,7 +4,7 @@ import { DropHandler } from "./DropHandler";
 
 export class CopyExternalFileInProjects extends DropHandler {
     public async canHandle(source: TreeItem, target: TreeItem): Promise<boolean> {
-        return source.contextValue === ContextValues.projectFile
+        return ContextValues.matchAnyLanguage(ContextValues.projectFile, source.contextValue)
             && source.project !== target.project;
     }
 

--- a/src/tree/drop/CopyExternalFolderInProjects.ts
+++ b/src/tree/drop/CopyExternalFolderInProjects.ts
@@ -8,7 +8,7 @@ import { Project } from "@core/Projects";
 
 export class CopyExternalFolderInProjects extends DropHandler {
     public async canHandle(source: TreeItem, target: TreeItem): Promise<boolean> {
-        return source.contextValue === ContextValues.projectFolder
+        return ContextValues.matchAnyLanguage(ContextValues.projectFolder, source.contextValue)
             && source.project !== target.project;
     }
 

--- a/src/tree/drop/MoveFileInTheSameProject.ts
+++ b/src/tree/drop/MoveFileInTheSameProject.ts
@@ -4,7 +4,7 @@ import { DropHandler } from "./DropHandler";
 
 export class MoveFileInTheSameProject extends DropHandler {
     public async canHandle(source: TreeItem, target: TreeItem): Promise<boolean> {
-        return source.contextValue === ContextValues.projectFile
+        return ContextValues.matchAnyLanguage(ContextValues.projectFile, source.contextValue) 
             && source.project === target.project;
     }
 

--- a/src/tree/drop/MoveFolderInTheSameProject.ts
+++ b/src/tree/drop/MoveFolderInTheSameProject.ts
@@ -4,7 +4,7 @@ import { DropHandler } from "./DropHandler";
 
 export class MoveFolderInTheSameProject extends DropHandler {
     public async canHandle(source: TreeItem, target: TreeItem): Promise<boolean> {
-        return source.contextValue === ContextValues.projectFolder
+        return ContextValues.matchAnyLanguage(ContextValues.projectFolder, source.contextValue)
             && source.project === target.project;
     }
 

--- a/src/tree/drop/MoveSolutionFolderInTheSameSolution.ts
+++ b/src/tree/drop/MoveSolutionFolderInTheSameSolution.ts
@@ -28,7 +28,7 @@ export class MoveSolutionFolderInTheSameSolution extends DropHandler {
     }
 
     protected isSolution(item: TreeItem): boolean {
-        return item.contextValue.startsWith(ContextValues.solution) && !item.projectInSolution;
+        return ContextValues.matchAnyLanguage(ContextValues.solution, item.contextValue) && !item.projectInSolution;
     }
 
     protected isValidTarget(item: TreeItem): boolean {


### PR DESCRIPTION
Refactored the language-agnostic context value check into a function, then used it in drop handlers to enable drag drop for F# projects.

Does not support file ordering via drag & drop, but makes sorting files into folders much easier.