### PR TITLE
Update the add new project template value

### DIFF
--- a/src/commands/AddNewProjectCommand.ts
+++ b/src/commands/AddNewProjectCommand.ts
@@ -113,7 +113,7 @@ export class AddNewProjectCommand extends SingleItemActionsCommand {
                 if (parts.length > 2) {
                     const projectType = {
                         name: parts[0].trim(),
-                        value: parts[1].trim(),
+                        value: parts[1].trim().split(',')[0],
                         languages: parts[2].split(',').map(element => element.trim().replace('[', '').replace(']', ''))
                     };
                     if (projectType.languages.length > 0) {


### PR DESCRIPTION
The current implementation doesn't take into account templates that support multiple values, like: ASP.NET Core Web App, it can be created using either webapp or razor. The current implementation try to create the project using webapp,razor value, that's incorrect and shows an error