### PR TITLE
Restore permission to allow move folder up/down

### DIFF
--- a/src/commands/MoveFileDownCommand.ts
+++ b/src/commands/MoveFileDownCommand.ts
@@ -10,7 +10,8 @@ export class MoveFileDownCommand extends SingleItemActionsCommand {
     }
 
     public shouldRun(item: TreeItem | undefined): boolean {
-        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path && ContextValues.matchAnyLanguage(ContextValues.projectFile, item.contextValue);
+        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path 
+        && (ContextValues.matchAnyLanguage(ContextValues.projectFile, item.contextValue) || ContextValues.matchAnyLanguage(ContextValues.projectFolder, item.contextValue));
     }
 
     public async getActions(item: TreeItem | undefined): Promise<Action[]> {

--- a/src/commands/MoveFileUpCommand.ts
+++ b/src/commands/MoveFileUpCommand.ts
@@ -10,7 +10,8 @@ export class MoveFileUpCommand extends SingleItemActionsCommand {
     }
 
     public shouldRun(item: TreeItem | undefined): boolean {
-        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path && ContextValues.matchAnyLanguage(ContextValues.projectFile, item.contextValue);
+        return !!item && !!item.project && item.project.extension.toLocaleLowerCase() === 'fsproj' && !!item.path 
+        && (ContextValues.matchAnyLanguage(ContextValues.projectFile, item.contextValue) || ContextValues.matchAnyLanguage(ContextValues.projectFolder, item.contextValue));
     }
 
     public async getActions(item: TreeItem | undefined): Promise<Action[]> {


### PR DESCRIPTION
The live version currently displays move up/down for F# folders, but the buttons don't actually do anything.
Looks like the condition update got clobbered in the merge with drag/drop for F#.
