### PR TITLE
Fix detect package version and sort versions

### DIFF
--- a/src/language/actions/NugetVersionCodeActionProvider.ts
+++ b/src/language/actions/NugetVersionCodeActionProvider.ts
@@ -5,7 +5,7 @@ export class NugetVersionCodeActionProvider implements vscode.CodeActionProvider
     private readonly regEx: RegExp;
 
     constructor(tagName: string) {
-        this.regEx = new RegExp(`<${tagName} Include="(.*)" Version="(.*)"`);
+        this.regEx = new RegExp(`<${tagName} Include="(.+)" Version="([0-9A-Za-z-.]+)"`);
     }
 
     async provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<(vscode.CodeAction | vscode.Command)[] | null | undefined> {

--- a/src/language/decorators/NugetVersionDecorator.ts
+++ b/src/language/decorators/NugetVersionDecorator.ts
@@ -32,7 +32,7 @@ export class NugetVersionDecorator implements ICodeDecorator
     private readonly regEx: RegExp;
 
     constructor(public readonly filter: vscode.DocumentSelector, tagName: string) {
-        this.regEx = new RegExp(`<${tagName} Include="(.+)" Version="(.+)"`, "g");
+        this.regEx = new RegExp(`<${tagName} Include="(.+)" Version="([0-9A-Za-z-.]+)"`, "g");
     }
 
     async decorate(editor: vscode.TextEditor): Promise<void> {
@@ -48,7 +48,7 @@ export class NugetVersionDecorator implements ICodeDecorator
                 continue;
             }
 
-            const isNew = versions[0] !== version;
+            const isNew = nuget.comparePackageVersions(version, versions[0]) > 0;
             const versionIndex = match.index + match[0].indexOf(version);
             const startPos = editor.document.positionAt(versionIndex - 1);
             const endPos = editor.document.positionAt(versionIndex + match[2].length + 1);


### PR DESCRIPTION
**This fix solves three problems:**

1) As described here https://github.com/fernandoescolar/vscode-solution-explorer/issues/316. When PackageReference have any tag after Version tag, extension dont detect package version. 
2) The current sorting of package versions does not take into account that the version may consist of more than just numbers.
3) If the package for some reason cannot be found. There is no check that it is the latest version. For pre-release packages, this is expressed in the fact that the extension writes that the package needs to be updated, but when you select a version, it offers versions lower than the installed one.

**After fix it looks like this:**

Current version detect
![изображение](https://github.com/user-attachments/assets/f10b5d14-953d-46a5-8264-243d99793b1e)
Version sort by semantic versioning
![изображение](https://github.com/user-attachments/assets/f1e6cb88-8d84-44d0-9a7c-90d88fb094ad)
Icon not show that we can update package
![изображение](https://github.com/user-attachments/assets/7fa204fb-8ab4-4912-a8d4-64702052e768)

