### PR TITLE
activate editor change only tree view visible

### DIFF
--- a/src/SolutionExplorerProvider.ts
+++ b/src/SolutionExplorerProvider.ts
@@ -201,6 +201,8 @@ export class SolutionExplorerProvider extends vscode.Disposable implements vscod
 		if (!shouldExecute) { return; }
 		if (!vscode.window.activeTextEditor) { return; }
 		if (vscode.window.activeTextEditor.document.uri.scheme !== 'file') { return; }
+		const showMode = config.getShowMode();
+		if (showMode === "activityBar" && !this.treeView?.visible) { return; }
 
 		this.selectActiveDocument();
 	}


### PR DESCRIPTION
This is a pull request that does not apply Track Active Item even when other items (e.g., Explorer, Git) are open in the navigation bar.

Previously, clicking an item in the Git tab to view Git changes per file would force the navigation bar window to switch, causing inconvenience. This change addresses that inconvenience.